### PR TITLE
docs: update service name to 'statistics-for-strava' in Ofelia config

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,7 +28,7 @@ Start off by showing some :heart: and give this repo a star. Then from your comm
 
 ```yml
 services:
-  app:
+  statistics-for-strava:
     image: robiningelbrecht/strava-statistics:latest
     container_name: statistics-for-strava
     restart: unless-stopped

--- a/docs/getting-started/scheduling.md
+++ b/docs/getting-started/scheduling.md
@@ -47,12 +47,12 @@ bin/console app:strava:import-data
 bin/console app:strava:build-files
 ```
 
-Edit `docker-compose.yml` to include the shell script as well as the Ofelia image. 
+Edit `docker-compose.yml` to include the shell script as well as the Ofelia image.
 Make sure the path to the shell script matches its location on your system.
 
 ```yml
 services:
-  app:
+  statistics-for-strava:
     image: robiningelbrecht/strava-statistics:latest
     volumes:
       - ./refresh.sh:/bin/refresh.sh


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [x] Documentation Update

## Description

This PR updates the docker-compose.yml examples in the documentation to use the consistent service name `statistics-for-strava` instead of `app`. This makes the documentation more consistent and prevents confusion when setting up Ofelia scheduling.
