### PR TITLE
Minor change for Ofelia docs example config

### DIFF
--- a/docs/getting-started/scheduling.md
+++ b/docs/getting-started/scheduling.md
@@ -47,7 +47,7 @@ bin/console app:strava:import-data
 bin/console app:strava:build-files
 ```
 
-Edit `docker-compose.yml` to include the shell script as well as the Ofelia image. 
+Edit `docker-compose.yml` to include the shell script as well as the Ofelia image.
 Make sure the path to the shell script matches its location on your system.
 
 ```yml
@@ -66,7 +66,7 @@ services:
   ofelia:
     image: mcuadros/ofelia:latest
     depends_on:
-      - statistics-for-strava
+      - app
     command: daemon --docker
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

_I see you haven't updated the docs yet, so here's my second attempt. 
Feel free to close this without merging._ 

The Ofelia Docker config example in the Scheduling docs doesn't work as it _depends_on: statistics-for-strava_. 
Error: `service "ofelia" depends on undefined service "statistics-for-strava": invalid compose project`

The simple fix is to change depends_on to _depends_on: app_ keeping it consistent across docs. 

See also [#1256](https://github.com/robiningelbrecht/statistics-for-strava/pull/1256)
