### PR TITLE
Ensure docker-compose in documentation is valid

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -43,6 +43,8 @@ services:
       start_period: 60s
     ports:
       - 8080:8080
+    networks:
+      - statistics-for-strava-network
 
   # ⚠️ This container is optional, it is not required to run Statistics for Strava.
   # Its purpose is to handle recurring background tasks, such as:
@@ -66,6 +68,9 @@ services:
     entrypoint: ['bin/console', 'app:daemon:run']
     networks:
       - statistics-for-strava-network
+
+networks:
+  statistics-for-strava-network:
 ```
 
 ## .env


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [x] Documentation Update

## Description

This ensures that the docker-compose in documentation is valid and can be used straight out of the box.
