### PR TITLE
Add strava-webhooks to sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
   - [Custom gear](configuration/custom-gear.md "Statistics for Strava | Custom gear")
   - [Gear maintenance](configuration/gear-maintenance.md "Statistics for Strava | Gear maintenance")
   - [AI integration](configuration/ai-integration.md "Statistics for Strava | AI integration")
+  - [Strava-webhooks](configuration/strava-webhooks "Statistics for Strava | Strava-webhooks")
   
 - Troubleshooting
 


### PR DESCRIPTION
Add strava-webhooks to sidebar

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [x] Documentation Update

## Description

Fixes Strava-webhooks not being in sidebar of docs
