### PR TITLE
Add OpenRouter AI provider integration

### DIFF
--- a/docs/configuration/ai-integration.md
+++ b/docs/configuration/ai-integration.md
@@ -29,6 +29,32 @@ integrations:
       model: 'MODEL-NAME'
 ```
 
+## OpenRouter
+
+<a href="https://openrouter.ai">OpenRouter</a> provides a unified API to access 400+ models from providers like OpenAI, Anthropic, Google, and more using a single API key. OpenRouter also offers <a href="https://openrouter.ai/collections/free-models">free models</a> to get started without any cost.
+
+To get started:
+
+1. Create an account at <a href="https://openrouter.ai">openrouter.ai</a>
+2. Generate an API key at <a href="https://openrouter.ai/keys">openrouter.ai/keys</a>
+3. Choose a model from the <a href="https://openrouter.ai/models">model list</a>
+
+Then configure your `config.yaml`:
+
+```yaml
+integrations:
+  ai:
+    enabled: true
+    enableUI: true
+    provider: 'openRouter'
+    configuration:
+      key: 'sk-or-v1-your-api-key'
+      model: 'anthropic/claude-sonnet-4.5'
+```
+
+> [!TIP]
+> **Tip** Popular models include `anthropic/claude-sonnet-4.5` and `google/gemini-3-flash-preview`.
+
 ## Locally hosted Ollama
 
 You can also run a local model using Ollama. Start by configuring a Docker container for Ollama:

--- a/src/Domain/Integration/AI/AIProviderFactory.php
+++ b/src/Domain/Integration/AI/AIProviderFactory.php
@@ -36,6 +36,7 @@ final readonly class AIProviderFactory
             'ollama' => ['model', 'url'],
             'azureOpenAI' => ['key', 'endpoint', 'model', 'version'],
             'openAILike' => ['baseUri', 'key', 'model'],
+            'openRouter' => ['key', 'model'],
             default => ['model', 'key'],
         };
 
@@ -82,6 +83,10 @@ final readonly class AIProviderFactory
             ),
             'openAILike' => new OpenAILike(
                 baseUri: $config['baseUri'],
+                key: $config['key'],
+                model: $config['model'],
+            ),
+            'openRouter' => new OpenRouter(
                 key: $config['key'],
                 model: $config['model'],
             ),

--- a/src/Domain/Integration/AI/OpenRouter.php
+++ b/src/Domain/Integration/AI/OpenRouter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integration\AI;
+
+use NeuronAI\Providers\OpenAI\OpenAI;
+
+final class OpenRouter extends OpenAI
+{
+    protected string $baseUri = 'https://openrouter.ai/api/v1';
+}


### PR DESCRIPTION
OpenRouter provides a unified API to access 400+ models from multiple providers (OpenAI, Anthropic, Google, etc.) using a single API key.

- Add OpenRouter provider class extending OpenAI with custom base URI
- Register openRouter in AIProviderFactory
- Add documentation section with setup instructions and model examples