### PR TITLE
Lap Bar Plot Height Changes

### DIFF
--- a/migrations/Version20260121012500.php
+++ b/migrations/Version20260121012500.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260121012500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add minMovingTimeInSeconds and maxMovingTimeInSeconds to ActivityLap';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql(<<<'SQL'
+            DELETE FROM ActivityLap
+        SQL);
+        $this->addSql('ALTER TABLE ActivityLap ADD COLUMN minMovingTimeInSeconds INTEGER NOT NULL');
+        $this->addSql('ALTER TABLE ActivityLap ADD COLUMN maxMovingTimeInSeconds INTEGER NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}

--- a/migrations/Version20260121012500.php
+++ b/migrations/Version20260121012500.php
@@ -20,6 +20,8 @@ final class Version20260121012500 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
+        // We need to delete existing laps because we're adding new required columns
+        // and there's no way to calculate historical min/max moving times
         $this->addSql(<<<'SQL'
             DELETE FROM ActivityLap
         SQL);
@@ -30,5 +32,7 @@ final class Version20260121012500 extends AbstractMigration
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE ActivityLap DROP COLUMN minMovingTimeInSeconds');
+        $this->addSql('ALTER TABLE ActivityLap DROP COLUMN maxMovingTimeInSeconds');
     }
 }

--- a/src/Application/Import/ProcessRawActivityData/Pipeline/ProcessActivityLaps.php
+++ b/src/Application/Import/ProcessRawActivityData/Pipeline/ProcessActivityLaps.php
@@ -50,6 +50,8 @@ final readonly class ProcessActivityLaps implements ProcessRawDataStep
                     maxSpeed: MetersPerSecond::from($lap['max_speed']),
                     elevationDifference: Meter::from($lap['total_elevation_gain'] ?? 0),
                     averageHeartRate: !empty($lap['average_heartrate']) ? (int) round($lap['average_heartrate']) : null,
+                    minMovingTimeInSeconds: $lap['min_moving_time'],
+                    maxMovingTimeInSeconds: $lap['max_moving_time'],
                 ));
                 ++$countLapsAdded;
             }

--- a/src/Domain/Activity/ActivityWithRawData.php
+++ b/src/Domain/Activity/ActivityWithRawData.php
@@ -98,11 +98,15 @@ final readonly class ActivityWithRawData
     {
         /** @var non-empty-array<float> $averageSpeeds */
         $averageSpeeds = array_column($this->rawData['laps'] ?? [], 'average_speed');
+        /** @var non-empty-array<int> $movingTimes */
+        $movingTimes = array_column($this->rawData['laps'] ?? [], 'moving_time');
 
         return array_map(
             fn (array $split): array => array_merge($split, [
                 'min_average_speed' => min($averageSpeeds),
                 'max_average_speed' => max($averageSpeeds),
+                'min_moving_time' => min($movingTimes),
+                'max_moving_time' => max($movingTimes),
             ]),
             $this->rawData['laps'] ?? [],
         );

--- a/src/Domain/Activity/Lap/ActivityLap.php
+++ b/src/Domain/Activity/Lap/ActivityLap.php
@@ -47,6 +47,10 @@ final readonly class ActivityLap implements SupportsAITooling
         private Meter $elevationDifference,
         #[ORM\Column(type: 'integer', nullable: true)]
         private ?int $averageHeartRate,
+        #[ORM\Column(type: 'integer')]
+        private int $minMovingTimeInSeconds,
+        #[ORM\Column(type: 'integer')]
+        private int $maxMovingTimeInSeconds,
     ) {
     }
 
@@ -64,6 +68,8 @@ final readonly class ActivityLap implements SupportsAITooling
         MetersPerSecond $maxSpeed,
         Meter $elevationDifference,
         ?int $averageHeartRate,
+        int $minMovingTimeInSeconds,
+        int $maxMovingTimeInSeconds,
     ): self {
         return new self(
             lapId: $lapId,
@@ -79,6 +85,8 @@ final readonly class ActivityLap implements SupportsAITooling
             maxSpeed: $maxSpeed,
             elevationDifference: $elevationDifference,
             averageHeartRate: $averageHeartRate,
+            minMovingTimeInSeconds: $minMovingTimeInSeconds,
+            maxMovingTimeInSeconds: $maxMovingTimeInSeconds,
         );
     }
 
@@ -96,6 +104,8 @@ final readonly class ActivityLap implements SupportsAITooling
         MetersPerSecond $maxSpeed,
         Meter $elevationDifference,
         ?int $averageHeartRate,
+        int $minMovingTimeInSeconds,
+        int $maxMovingTimeInSeconds,
     ): self {
         return new self(
             lapId: $lapId,
@@ -111,6 +121,8 @@ final readonly class ActivityLap implements SupportsAITooling
             maxSpeed: $maxSpeed,
             elevationDifference: $elevationDifference,
             averageHeartRate: $averageHeartRate,
+            minMovingTimeInSeconds: $minMovingTimeInSeconds,
+            maxMovingTimeInSeconds: $maxMovingTimeInSeconds,
         );
     }
 
@@ -197,6 +209,21 @@ final readonly class ActivityLap implements SupportsAITooling
         return round($relative, 2);
     }
 
+    public function getRelativeMovingTimePercentage(): float
+    {
+        $maxMovingTime = $this->getMaxMovingTimeInSeconds();
+
+        if ($maxMovingTime <= 0) {
+            return 0.0;
+        }
+
+        $movingTime = $this->getMovingTimeInSeconds();
+        $relative = ($movingTime / $maxMovingTime) * 100;
+        $relative = max(0, min(100, $relative));
+
+        return round($relative, 2);
+    }
+
     public function getMinAverageSpeed(): MetersPerSecond
     {
         return $this->minAverageSpeed;
@@ -220,6 +247,16 @@ final readonly class ActivityLap implements SupportsAITooling
     public function getAverageHeartRate(): ?int
     {
         return $this->averageHeartRate;
+    }
+
+    public function getMinMovingTimeInSeconds(): int
+    {
+        return $this->minMovingTimeInSeconds;
+    }
+
+    public function getMaxMovingTimeInSeconds(): int
+    {
+        return $this->maxMovingTimeInSeconds;
     }
 
     /**

--- a/src/Domain/Activity/Lap/ActivityLap.php
+++ b/src/Domain/Activity/Lap/ActivityLap.php
@@ -213,7 +213,7 @@ final readonly class ActivityLap implements SupportsAITooling
     {
         $maxMovingTime = $this->getMaxMovingTimeInSeconds();
 
-        if ($maxMovingTime <= 0) {
+        if ($maxMovingTime === 0) {
             return 0.0;
         }
 

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -131,7 +131,10 @@
                                 <div class="w-32 px-2 py-2">{{ "HR"|trans }}</div>
                             </div>
                             {% for lap in laps %}
-                                <div class="flex items-center border-b last:border-b-0" style="height: {{ lap.getRelativeMovingTimePercentage() }}%;">
+                                {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
+                                {% set maxHeight = 80 %}
+                                {% set calculatedHeight = (maxHeight * heightPercentage / 100)|round(1) %}
+                                <div class="flex items-center border-b last:border-b-0" style="height: {{ calculatedHeight }}px; min-height: {{ calculatedHeight }}px;">
                                     <div class="w-8 px-2 py-2 font-bold">
                                         {{ lap.getLapNumber() }}
                                     </div>

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -131,7 +131,7 @@
                                 <div class="w-32 px-2 py-2">{{ "HR"|trans }}</div>
                             </div>
                             {% for lap in laps %}
-                                <div class="flex items-center border-b last:border-b-0">
+                                <div class="flex items-center border-b last:border-b-0" style="height: {{ lap.getRelativeMovingTimePercentage() }}%;">
                                     <div class="w-8 px-2 py-2 font-bold">
                                         {{ lap.getLapNumber() }}
                                     </div>

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -133,7 +133,9 @@
                             {% for lap in laps %}
                                 {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
                                 {% set maxHeight = 80 %}
+                                {% set maxBarHeight = 20 %}
                                 {% set calculatedHeight = (maxHeight * heightPercentage / 100)|round(1) %}
+                                {% set calculatedBarHeight = (maxBarHeight * heightPercentage / 100)|round(1) %}
                                 <div class="flex items-center border-b last:border-b-0" style="height: {{ calculatedHeight }}px; min-height: {{ calculatedHeight }}px;">
                                     <div class="w-8 px-2 py-2 font-bold">
                                         {{ lap.getLapNumber() }}
@@ -148,8 +150,8 @@
                                         {{ lap.getPaceInSecPerKm()|formatPace }}
                                     </div>
                                     <div class="grow min-w-40 px-2 py-2">
-                                        <div class=" bg-gray-200 rounded-full h-2.5">
-                                            <div class="bg-strava-orange h-2.5 rounded-full" style="width: {{ lap.getRelativePacePercentage() }}%"></div>
+                                        <div class="bg-gray-200 rounded-full" style="height: {{ calculatedBarHeight }}px;">
+                                            <div class="bg-strava-orange rounded-full" style="width: {{ lap.getRelativePacePercentage() }}%; height: {{ calculatedBarHeight }}px;"></div>
                                         </div>
                                     </div>
                                     <div class="w-32 px-2 py-2">

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -132,7 +132,7 @@
                             </div>
                             {% for lap in laps %}
                                 {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
-                                {% set maxBarHeight = 20 %}
+                                {% set maxBarHeight = 50 %}
                                 {% set calculatedBarHeight = (maxBarHeight * heightPercentage / 100)|round(1) %}
                                 <div class="flex items-center" style="margin-bottom: 3px;">
                                     <div class="w-8 px-2 py-1 font-bold">

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -132,37 +132,35 @@
                             </div>
                             {% for lap in laps %}
                                 {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
-                                {% set maxHeight = 80 %}
                                 {% set maxBarHeight = 20 %}
-                                {% set calculatedHeight = (maxHeight * heightPercentage / 100)|round(1) %}
                                 {% set calculatedBarHeight = (maxBarHeight * heightPercentage / 100)|round(1) %}
-                                <div class="flex items-center border-b last:border-b-0" style="height: {{ calculatedHeight }}px; min-height: {{ calculatedHeight }}px;">
-                                    <div class="w-8 px-2 py-2 font-bold">
+                                <div class="flex items-center" style="margin-bottom: 3px;">
+                                    <div class="w-8 px-2 py-1 font-bold">
                                         {{ lap.getLapNumber() }}
                                     </div>
-                                    <div class="w-32 px-2 py-2">
+                                    <div class="w-32 px-2 py-1">
                                         {{ lap.getDistanceInKilometer()|renderMeasurement(1) }}
                                     </div>
-                                    <div class="w-32 px-2 py-2">
+                                    <div class="w-32 px-2 py-1">
                                         {{ lap.getMovingTimeFormatted() }}
                                     </div>
-                                    <div class="w-32 px-2 py-2">
+                                    <div class="w-32 px-2 py-1">
                                         {{ lap.getPaceInSecPerKm()|formatPace }}
                                     </div>
-                                    <div class="grow min-w-40 px-2 py-2">
+                                    <div class="grow min-w-40 px-2 py-1">
                                         <div class="bg-gray-200 rounded-full" style="height: {{ calculatedBarHeight }}px;">
                                             <div class="bg-strava-orange rounded-full" style="width: {{ lap.getRelativePacePercentage() }}%; height: {{ calculatedBarHeight }}px;"></div>
                                         </div>
                                     </div>
-                                    <div class="w-32 px-2 py-2">
+                                    <div class="w-32 px-2 py-1">
                                         {{ lap.getElevationDifference()|renderMeasurement(0) }}
                                     </div>
                                     {% if lap.getAverageHeartRate() %}
-                                        <div class="w-32 px-2 py-2">
+                                        <div class="w-32 px-2 py-1">
                                             {{ lap.getAverageHeartRate() }}
                                         </div>
                                     {% else %}
-                                        <div class="w-32 px-2 py-2">
+                                        <div class="w-32 px-2 py-1">
                                             {{ "n/a"|trans }}
                                         </div>
                                     {% endif %}

--- a/templates/html/activity/activity--sport-type--run.html.twig
+++ b/templates/html/activity/activity--sport-type--run.html.twig
@@ -148,8 +148,8 @@
                                         {{ lap.getPaceInSecPerKm()|formatPace }}
                                     </div>
                                     <div class="grow min-w-40 px-2 py-1">
-                                        <div class="bg-gray-200 rounded-full" style="height: {{ calculatedBarHeight }}px;">
-                                            <div class="bg-strava-orange rounded-full" style="width: {{ lap.getRelativePacePercentage() }}%; height: {{ calculatedBarHeight }}px;"></div>
+                                        <div class="bg-gray-200 rounded" style="height: {{ calculatedBarHeight }}px;">
+                                            <div class="bg-strava-orange rounded" style="width: {{ lap.getRelativePacePercentage() }}%; height: {{ calculatedBarHeight }}px;"></div>
                                         </div>
                                     </div>
                                     <div class="w-32 px-2 py-1">

--- a/templates/html/activity/activity--sport-type--swim.html.twig
+++ b/templates/html/activity/activity--sport-type--swim.html.twig
@@ -79,7 +79,10 @@
                                     <div class="w-32 px-2 py-2">{{ "HR"|trans }}</div>
                                 </div>
                                 {% for lap in laps %}
-                                    <div class="flex items-center border-b last:border-b-0" style="height: {{ lap.getRelativeMovingTimePercentage() }}%;">
+                                    {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
+                                    {% set maxHeight = 80 %}
+                                    {% set calculatedHeight = (maxHeight * heightPercentage / 100)|round(1) %}
+                                    <div class="flex items-center border-b last:border-b-0" style="height: {{ calculatedHeight }}px; min-height: {{ calculatedHeight }}px;">
                                         <div class="w-8 px-2 py-2 font-bold">
                                             {{ lap.getLapNumber() }}
                                         </div>

--- a/templates/html/activity/activity--sport-type--swim.html.twig
+++ b/templates/html/activity/activity--sport-type--swim.html.twig
@@ -79,7 +79,7 @@
                                     <div class="w-32 px-2 py-2">{{ "HR"|trans }}</div>
                                 </div>
                                 {% for lap in laps %}
-                                    <div class="flex items-center border-b last:border-b-0">
+                                    <div class="flex items-center border-b last:border-b-0" style="height: {{ lap.getRelativeMovingTimePercentage() }}%;">
                                         <div class="w-8 px-2 py-2 font-bold">
                                             {{ lap.getLapNumber() }}
                                         </div>

--- a/templates/html/activity/activity--sport-type--swim.html.twig
+++ b/templates/html/activity/activity--sport-type--swim.html.twig
@@ -79,10 +79,7 @@
                                     <div class="w-32 px-2 py-2">{{ "HR"|trans }}</div>
                                 </div>
                                 {% for lap in laps %}
-                                    {% set heightPercentage = lap.getRelativeMovingTimePercentage() %}
-                                    {% set maxHeight = 80 %}
-                                    {% set calculatedHeight = (maxHeight * heightPercentage / 100)|round(1) %}
-                                    <div class="flex items-center border-b last:border-b-0" style="height: {{ calculatedHeight }}px; min-height: {{ calculatedHeight }}px;">
+                                    <div class="flex items-center border-b last:border-b-0">
                                         <div class="w-8 px-2 py-2 font-bold">
                                             {{ lap.getLapNumber() }}
                                         </div>

--- a/tests/Domain/Activity/Lap/ActivityLapBuilder.php
+++ b/tests/Domain/Activity/Lap/ActivityLapBuilder.php
@@ -25,6 +25,8 @@ final class ActivityLapBuilder
     private MetersPerSecond $maxSpeed;
     private readonly Meter $elevationDifference;
     private readonly ?int $averageHeartRate;
+    private readonly int $minMovingTimeInSeconds;
+    private readonly int $maxMovingTimeInSeconds;
 
     private function __construct()
     {
@@ -41,6 +43,8 @@ final class ActivityLapBuilder
         $this->maxAverageSpeed = MetersPerSecond::from(8);
         $this->maxSpeed = MetersPerSecond::from(8);
         $this->averageHeartRate = null;
+        $this->minMovingTimeInSeconds = 100;
+        $this->maxMovingTimeInSeconds = 200;
     }
 
     public static function fromDefaults(): self
@@ -64,6 +68,8 @@ final class ActivityLapBuilder
             maxSpeed: $this->maxSpeed,
             elevationDifference: $this->elevationDifference,
             averageHeartRate: $this->averageHeartRate,
+            minMovingTimeInSeconds: $this->minMovingTimeInSeconds,
+            maxMovingTimeInSeconds: $this->maxMovingTimeInSeconds,
         );
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

Adds variable height bar plots for laps, where the orange pace bar heights represent moving time spent in each lap, normalized by the maximum lap time. 

Note: This was largely vibe coded using Copolit GPT-5.1-Codex. 

Original Lap View: 
<img width="670" height="377" alt="image" src="https://github.com/user-attachments/assets/137e704a-092b-4809-a802-a44b506f7f18" />


Updated Lap View: 
<img width="652" height="338" alt="image" src="https://github.com/user-attachments/assets/ce2c66af-34b8-470c-a77f-a40006bc1f86" />


### Changes Made:

#### Domain Model Updates:
- Added `minMovingTimeInSeconds` and `maxMovingTimeInSeconds` fields to `ActivityLap` entity
- Added `getRelativeMovingTimePercentage()` method that calculates the lap's moving time as a percentage of the max lap time
- Updated `ActivityWithRawData.getLaps()` to calculate and include min/max moving times across all laps

#### Data Processing:
- Updated `ProcessActivityLaps` to pass min/max moving time values when creating lap entities

#### UI Changes:
- Run activity template displays pace bars with variable heights (0-50px)
- Bars are stacked with consistent 3px spacing
- **Bar corners** use standard radius (sharper corners instead of fully rounded)
- **Bar heights** scale based on moving time (y-axis)
- **Bar widths** continue to show pace percentage (x-axis)
- Swim activities show uniform rows (no pace bars)

#### Database:
- Created migration to add the new columns to the ActivityLap table
- Included proper rollback mechanism in down() migration

#### Testing:
- Updated `ActivityLapBuilder` test helper to include new fields with default values
- Verified PHP syntax on all modified files
- Code review completed and feedback addressed
- CodeQL security check passed

### Result:
- **Y-axis (bar height):** Represents moving time in seconds (normalized to percentage of max, 0-50px)
- **X-axis (bar width):** Represents pace percentage
- Row heights are uniform for compact display
- Bars are closely spaced (3px margin) for easy comparison
- Bar corners are sharper for cleaner appearance
- Run activities show time-proportional bar heights
- Swim activities show uniform rows (no bars)
