### PR TITLE
chore(i18n): improve Italian translations

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -1098,17 +1098,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     doctrine?: DoctrineConfig,
  *     doctrine_migrations?: DoctrineMigrationsConfig,
  *     twig?: TwigConfig,
- *     "when@dev"?: array{
- *         imports?: ImportsConfig,
- *         parameters?: ParametersConfig,
- *         services?: ServicesConfig,
- *         framework?: FrameworkConfig,
- *         flysystem?: FlysystemConfig,
- *         monolog?: MonologConfig,
- *         doctrine?: DoctrineConfig,
- *         doctrine_migrations?: DoctrineMigrationsConfig,
- *         twig?: TwigConfig,
- *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1214,7 +1203,6 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     deprecated?: array{package:string, version:string, message?:string},
  * }
  * @psalm-type RoutesConfig = array{
- *     "when@dev"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@prod"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     "when@test"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
  *     ...<string, RouteConfig|ImportConfig|AliasConfig>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
@@ -139,14 +139,14 @@
                                         <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"></path>
                                     </g>
                                 </svg>
-                                Strava profile
+                                Profilo Strava
                             </a>
                         </li>
                         <li class="border-t border-gray-200 pt-1.5">
                             <label for="darkModeToggle" class="dark-mode-toggle hover:bg-gray-50 rounded p-2 flex cursor-pointer items-center">
                                 <div class="inline-flex items-center">
                                     <svg class="w-4 h-4 me-1.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 21a9 9 0 0 1-.5-17.986V3c-.354.966-.5 1.911-.5 3a9 9 0 0 0 9 9c.239 0 .254.018.488 0A9.004 9.004 0 0 1 12 21Z"></path></svg>
-                                    <span class="text-sm font-medium text-heading">Dark mode</span>
+                                    <span class="text-sm font-medium text-heading">Modalit&agrave; scura</span>
                                 </div>
                                 <input id="darkModeToggle" type="checkbox" value="" class="peer sr-only">
                                 <div class="ms-auto peer peer-checked:after:border-buffer relative h-5 w-9 rounded-full bg-gray-200 peer-checked:bg-gray-100 peer-focus:outline-none after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full"></div>

--- a/translations/messages+intl-icu.it_IT.yaml
+++ b/translations/messages+intl-icu.it_IT.yaml
@@ -2,13 +2,13 @@
 '7-day fatigue level': 'Livello di fatica a 7 giorni'
 '< 1.5: Good variety in training': '< 1.5: Buona varietà di allenamento'
 '> 2.0: High monotony, increased risk': '> 2.0: Monotonia elevata, rischio aumentato'
-'A 6-hour week scores higher than a 5-hour week.': 'A 6-hour week scores higher than a 5-hour week.'
-'A high intensity score means a larger share of your training is hard rather than easy.': 'A high intensity score means a larger share of your training is hard rather than easy.'
-'A high score means you concentrate more training into fewer, heavier days.': 'A high score means you concentrate more training into fewer, heavier days.'
+'A 6-hour week scores higher than a 5-hour week.': 'Una settimana da 6 ore ottiene un punteggio più alto di una da 5 ore.'
+'A high intensity score means a larger share of your training is hard rather than easy.': 'Un punteggio di intensità alto significa che una quota maggiore del tuo allenamento è impegnativa invece che facile.'
+'A high score means you concentrate more training into fewer, heavier days.': 'Un punteggio alto significa che concentri più allenamento in meno giorni, ma più intensi.'
 'A:C Ratio': 'Rapporto A:C'
-'A:C optimal in': 'A:C optimal in'
+'A:C optimal in': 'A:C ottimale tra'
 'ATL (Fatigue)': 'ATL (Fatica)'
-'Accumulated fatigue': 'Accumulated fatigue'
+'Accumulated fatigue': 'Fatica accumulata'
 'Active days': 'Giornate attive'
 Activities: Attività
 Activity: Attività
@@ -25,14 +25,14 @@ All: Tutti
 'Alpine Ski': 'Sci alpino'
 Apr: Apr
 'Ask Mark something...': 'Chiedi qualcosa a Mark...'
-'Athlete profile': 'Athlete profile'
+'Athlete profile': 'Profilo atleta'
 Aug: Ago
-'Average gradient': 'Average gradient'
+'Average gradient': 'Pendenza media'
 Avg: Media
 'Back Country Ski': 'Sci fuoripista'
 Badges: Badges
 Badminton: Badminton
-Basketball: Basketball
+Basketball: Basket
 Best: Migliore
 'Best effort': 'Miglior sforzo'
 'Best efforts': 'Migliori Sforzi'
@@ -47,28 +47,28 @@ Canoeing: Canoa
 'Challenge consistency': 'Costanza nella sfida'
 Challenges: Sfide
 'Chronic Training Load (Fitness) - 42-day exponentially weighted average of your daily training load. Represents long-term training adaptation.': "Carico di Allenamento Cronico (Forma) - media esponenziale a 42 giorni del tuo carico giornaliero. Rappresenta l'adattamento a lungo termine."
-'Clear chat': 'Clear chat'
+'Clear chat': 'Cancella chat'
 'Close modal': 'Chiudi modale'
 'Collapse sidebar': 'Comprimi barra laterale'
 Commutes: 'Spostamenti quotidiani'
 'Commutes only': 'Solo spostamenti quotidiani'
 Compare: Confronta
 'Compare to': 'Confronta con'
-'Completed {threshold} activities': 'Completed {threshold} activities'
+'Completed {threshold} activities': 'Completate {threshold} attività'
 'Congrats! You achieved personal bests during this activity.': 'Complimenti! Hai raggiunto record personali durante questa attività.'
-'Consider reducing load': 'Consider reducing load'
+'Consider reducing load': 'Valuta di ridurre il carico'
 Consistency: Consistency
 Country: Country
 Cricket: Cricket
 Crossfit: Crossfit
-'Current Status': 'Current Status'
-'Current streaks': 'Current streaks'
+'Current Status': 'Stato attuale'
+'Current streaks': 'Serie attuali'
 'Custom gear disabled': 'Attrezzatura personalizzata disattivata'
 Cycling: Ciclismo
 'Daily TRIMP': 'TRIMP giornaliero'
 'Daily activities': 'Attività giornaliere'
 Dance: Dance
-'Dark mode': 'Dark mode'
+'Dark mode': 'Modalità scura'
 Dashboard: 'Schermata iniziale'
 Date: Data
 Day: Day
@@ -80,23 +80,23 @@ Density: Density
 Details: Dettagli
 Device: Dispositivo
 Distance: Distanza
-'Distance & Elevation': 'Distance & Elevation'
+'Distance & Elevation': 'Distanza e dislivello'
 'Distance breakdown': 'Analisi della distanza'
 'Distance in {unit}': 'Distanza in {unit}'
 'Distance over time per gear': 'Distanza nel tempo per attrezzatura'
 'Distance per month per gear': 'Distanza per mese per attrezzatura'
 Distribution: Distribuzione
-'Doing a mix of cycling, running, swimming, and strength work increases your variety score.': 'Doing a mix of cycling, running, swimming, and strength work increases your variety score.'
+'Doing a mix of cycling, running, swimming, and strength work increases your variety score.': 'Alternare ciclismo, corsa, nuoto e lavoro di forza aumenta il tuo punteggio di varietà.'
 Duration: Duration
 'E-Bike Rides': 'Uscite in e-bike'
 'E-Mountain Bike Rides': 'Uscite in e-mountain bike'
 Eddington: Eddington
-'Effort vs heart rate': 'Effort vs heart rate'
+'Effort vs heart rate': 'Sforzo vs frequenza cardiaca'
 Elev: Disl.
 Elevation: Dislivello
 'Elevation in {unit}': 'Dislivello in {unit}'
 Elliptical: Ellittica
-'Enter fullscreen mode': 'Enter fullscreen mode'
+'Enter fullscreen mode': 'Entra in modalità schermo intero'
 Evening: Sera
 'Excludes commutes': 'Esclude gli spostamenti casa-lavoro'
 'FTP history': 'Storico FTP'
@@ -107,12 +107,12 @@ Feb: Feb
 'Filter on country': 'Filtra per paese'
 'Filter on sport type': 'Filtra per tipo di sport'
 'Filter on starred segments': 'Filtra sui segmenti preferiti'
-'First activity in {countryName}': 'First activity in {countryName}'
-'First-ever activity recorded': 'First-ever activity recorded'
+'First activity in {countryName}': 'Prima attività in {countryName}'
+'First-ever activity recorded': 'Prima attività mai registrata'
 Firsts: Firsts
 Fitness: 'Forma fisica'
-'Fitness may be declining due to low recent training load': 'Fitness may be declining due to low recent training load'
-'Fitness may decline': 'Fitness may decline'
+'Fitness may be declining due to low recent training load': 'La forma potrebbe essere in calo a causa del basso carico di allenamento recente'
+'Fitness may decline': 'La forma potrebbe calare'
 'For example, an Eddington number of 70 would imply that a cyclist has cycled at least 70 km or miles in a day on at least 70 occasions. Achieving a high Eddington number is difficult, since moving from, say, 70 to 75 will (probably) require more than five new long-distance workouts, since any workout shorter than 75 km or miles will no longer be included in the reckoning.': 'Ad esempio, un numero di Eddington pari a 70 implicherebbe che un ciclista ha percorso almeno 70 km o miglia al giorno in almeno 70 occasioni. Raggiungere un numero di Eddington elevato è difficile, poiché passare, ad esempio, da 70 a 75 richiederà (probabilmente) più di cinque nuovi allenamenti a lunga distanza, dato che qualsiasi allenamento inferiore a 75 km o miglia non sarà più incluso nel calcolo.'
 'Form (TSB)': 'Forma (TSB)'
 Fri: Ven
@@ -140,19 +140,19 @@ HR: FC
 'Heart rate zones': 'Zone frequenza cardiaca'
 Heatmap: 'Mappa di calore'
 High: Alto
-'High fatigue levels may increase injury or burnout risk. Consider reducing load and prioritizing recovery': 'High fatigue levels may increase injury or burnout risk. Consider reducing load and prioritizing recovery'
+'High fatigue levels may increase injury or burnout risk. Consider reducing load and prioritizing recovery': 'Livelli elevati di fatica possono aumentare il rischio di infortuni o burnout. Valuta di ridurre il carico e dare priorità al recupero'
 'High monotony - increase variety': 'Monotonia elevata - aumenta la varietà'
-'High risk': 'High risk'
-'Highly recovered and ready to perform': 'Highly recovered and ready to perform'
+'High risk': 'Rischio alto'
+'Highly recovered and ready to perform': 'Recupero elevato e pronto a performare'
 Hikes: Escursioni
 History: Cronologia
-'History (6 weeks)': 'History (6 weeks)'
-'How diverse is your training': 'How diverse is your training'
-'How hard is your typical training session': 'How hard is your typical training session'
-'How long is your typical training session': 'How long is your typical training session'
-'How much do you train on average per week': 'How much do you train on average per week'
-'How much training you do in total on days you train.': 'How much training you do in total on days you train.'
-'How often do you train': 'How often do you train'
+'History (6 weeks)': 'Storico (6 settimane)'
+'How diverse is your training': 'Quanto è vario il tuo allenamento'
+'How hard is your typical training session': 'Quanto è intensa la tua sessione di allenamento tipica'
+'How long is your typical training session': 'Quanto dura la tua sessione di allenamento tipica'
+'How much do you train on average per week': 'Quanto ti alleni in media ogni settimana'
+'How much training you do in total on days you train.': 'Quanto ti alleni complessivamente nei giorni in cui ti alleni.'
+'How often do you train': 'Con quale frequenza ti alleni'
 'Ice Skate': 'Pattinaggio su ghiaccio'
 Id: ID
 'Image "{imgSrc}" is referenced in your maintenance config file, but was not found in "storage/gear-maintenance"': 'L''immagine "{imgSrc}" è referenziata nel tuo file di configurazione della manutenzione, ma non è stata trovata in "storage/gear-maintenance"'
@@ -171,38 +171,38 @@ Kayaking: Kayak
 Lap: Giro
 Laps: Giri
 'Last 7 days training load': 'Carico di allenamento negli ultimi 7 giorni'
-'Last activity': 'Last activity'
+'Last activity': 'Ultima attività'
 'Last effort': 'Ultimo tentativo'
-'Last effort date': 'Last effort date'
+'Last effort date': 'Data dell’ultimo sforzo'
 'Last maintenance': 'Ultima manutenzione'
 'Last {numberOfDays} days': 'Ultimi {numberOfDays} giorni'
 Lifetime: Lifetime
-'Light fatigue with good readiness. A great balance for quality training or longer efforts': 'Light fatigue with good readiness. A great balance for quality training or longer efforts'
+'Light fatigue with good readiness. A great balance for quality training or longer efforts': 'Fatica leggera con buona prontezza. Un ottimo equilibrio per allenamenti di qualità o sforzi più lunghi'
 Load: Load
 'Load (CTL/ATL)': 'Carico (CTL/ATL)'
 'Loading data...': 'Caricamento informazioni...'
 Loading...: Caricamento...
 'Locations over the globe': 'Luoghi nel mondo'
 'Long run': 'Corsa lunga'
-'Longest activity': 'Longest activity'
+'Longest activity': 'Attività più lunga'
 'Longest activity (h)': 'Attività più lunga (h)'
-'Longest distance': 'Longest distance'
+'Longest distance': 'Distanza più lunga'
 'Longest streaks': 'Serie più lunghe'
 Low: Basso
-'Low risk': 'Low risk'
-'Low training load': 'Low training load'
+'Low risk': 'Rischio basso'
+'Low training load': 'Carico di allenamento basso'
 Maintenance: Manutenzione
 'Maintenance history': 'Storico manutenzioni'
 Mar: Mar
 Max: Massimo
-'Max gradient': 'Max gradient'
+'Max gradient': 'Pendenza massima'
 May: Mag
 Medium: Medio
 Metric: Metric
 Metrics: Metriche
 Milestones: Milestones
 'Mind & Body Sports': 'Sport Mente e Corpo'
-'Moderate fatigue with stable fitness. Well suited for consistent day-to-day training': 'Moderate fatigue with stable fitness. Well suited for consistent day-to-day training'
+'Moderate fatigue with stable fitness. Well suited for consistent day-to-day training': 'Fatica moderata con forma stabile. Ben adatto a un allenamento costante giorno dopo giorno'
 'Moderate monotony': 'Monotonia moderata'
 Mon: Lun
 Monday: Lunedì
@@ -210,19 +210,19 @@ Monotony: Monotonia
 Monthly: Monthly
 'Monthly stats': 'Statistiche mensili'
 Morning: Mattina
-'Most elevation': 'Most elevation'
+'Most elevation': 'Maggiore dislivello'
 'Most recent activities': 'Attività più recenti'
 'Most recent challenges': 'Sfide più recenti'
-'Most recent milestones': 'Most recent milestones'
+'Most recent milestones': 'Traguardi più recenti'
 'Mountain Bike Rides': 'Uscite in mountain bike'
 'Moving time': 'Tempo in movimento'
 Name: Nome
 Neutral: Neutral
-'New personal best for': 'New personal best for'
+'New personal best for': 'Nuovo record personale per'
 Night: Notte
 'No activities': 'Nessuna attività'
 'No data available': 'Nessun dato disponibile'
-'No milestones achieved yet': 'No milestones achieved yet'
+'No milestones achieved yet': 'Nessun traguardo raggiunto finora'
 'No other options to compare with': "Nessun'altra opzione con cui confrontare"
 None: Nessuno
 'Nordic Ski': 'Sci nordico'
@@ -233,8 +233,8 @@ Now: Now
 'Number of activities per month': 'Numero di attività al mese'
 'Number of times completed': 'Numero di completamenti'
 Oct: Ott
-'Older effort': 'Older effort'
-'On average, that works out to {dailyAverage} per day, a weekly average of {weeklyAverage} and a monthly average of {monthlyAverage} 🐣.': 'On average, that works out to {dailyAverage} per day, a weekly average of {weeklyAverage} and a monthly average of {monthlyAverage} 🐣.'
+'Older effort': 'Sforzo meno recente'
+'On average, that works out to {dailyAverage} per day, a weekly average of {weeklyAverage} and a monthly average of {monthlyAverage} 🐣.': 'In media, questo equivale a {dailyAverage} al giorno, una media settimanale di {weeklyAverage} e una media mensile di {monthlyAverage} 🐣.'
 'One of your gear maintenance tasks is due': "Uno dei tuoi compiti di manutenzione dell'attrezzatura è in scadenza"
 'Optimal training range': 'Intervallo di allenamento ottimale'
 Other: Altro
@@ -247,12 +247,12 @@ Over-fatigued: Over-fatigued
 PRs: 'Record personali'
 'PRs achieved per month': 'Record Personali raggiunti al mese'
 Pace: Andatura
-'Pace distribution': 'Pace distribution'
+'Pace distribution': 'Distribuzione del passo'
 Padel: Padel
-'Peak fresh': 'Peak fresh'
+'Peak fresh': 'Picco di freschezza'
 'Peak power outputs': 'Picchi di potenza'
 'Personal Records': 'Record personali'
-'Personal bests': 'Personal bests'
+'Personal bests': 'Record personali'
 Photo: Foto
 Photos: Foto
 'Pickle Ball': Pickleball
@@ -269,16 +269,16 @@ Race: Gara
 'Racquet & Paddle Sports': 'Sport con racchetta e pagaia'
 'Racquet Ball': Racquetball
 Ranking: Classifica
-'Reached {threshold} hours total moving time': 'Reached {threshold} hours total moving time'
-'Reached {threshold} total distance': 'Reached {threshold} total distance'
-'Reached {threshold} total elevation': 'Reached {threshold} total elevation'
-'Recent effort': 'Recent effort'
-'Recording devices': 'Recording devices'
-'Recording devices details': 'Recording devices details'
-'Recovery Timeline': 'Recovery Timeline'
-'Recovery forecast': 'Recovery forecast'
+'Reached {threshold} hours total moving time': 'Raggiunte {threshold} ore di tempo totale in movimento'
+'Reached {threshold} total distance': 'Raggiunta distanza totale di {threshold}'
+'Reached {threshold} total elevation': 'Raggiunto dislivello totale di {threshold}'
+'Recent effort': 'Sforzo recente'
+'Recording devices': 'Dispositivi di registrazione'
+'Recording devices details': 'Dettagli dispositivi di registrazione'
+'Recovery Timeline': 'Timeline del recupero'
+'Recovery forecast': 'Previsione di recupero'
 'Reduced carbon emission by commuting': 'Emissioni di carbonio ridotte grazie agli spostamenti casa-lavoro'
-'Relative cost': 'Relative cost'
+'Relative cost': 'Costo relativo'
 'Rest Days': 'Giorni di riposo'
 'Rest days': 'Giorni di riposo'
 'Rest days in last 7 days': 'Giorni di riposo negli ultimi 7 giorni'
@@ -287,7 +287,7 @@ Ranking: Classifica
 Rewind: Indietro
 'Rewind comparisons are only available on larger screens.': 'I confronti Rewind sono disponibili solo su schermi più grandi.'
 Rides: Gare
-'Risk of detraining': 'Risk of detraining'
+'Risk of detraining': 'Rischio di detraining'
 'Rock Climbing': 'Arrampicata su roccia'
 'Roller Ski': Skiroll
 Rowing: Canottaggio
@@ -302,20 +302,20 @@ Search: Cerca
 Segments: Segmenti
 Sep: Set
 'Show information': 'Mostra Informazione'
-'Shows how your TSB (Form) and A:C Ratio will recover over time if you take complete rest days.': 'Shows how your TSB (Form) and A:C Ratio will recover over time if you take complete rest days.'
+'Shows how your TSB (Form) and A:C Ratio will recover over time if you take complete rest days.': 'Mostra come il tuo TSB (Forma) e il rapporto A:C recupereranno nel tempo se fai giorni di riposo completo.'
 "Since I began using Strava {numberOfDaysAgo} ago on {startDate}, I've logged {totalDaysOfWorkingOut} active days of training and adventure.": 'Da quando ho iniziato a usare Strava {numberOfDaysAgo} fa, il {startDate}, ho registrato {totalDaysOfWorkingOut} giorni attivi di allenamento e avventura.'
 Skateboard: Skateboard
 Skating: Pattinaggio
-'Slightly fresh': 'Slightly fresh'
+'Slightly fresh': 'Leggermente fresco'
 Snowboard: Snowboard
 Snowshoe: Ciaspolate
 Soccer: Calcio
 Socials: Social
-'Someone who regularly trains for 90 minutes will score higher than someone doing mostly short sessions.': 'Someone who regularly trains for 90 minutes will score higher than someone doing mostly short sessions.'
+'Someone who regularly trains for 90 minutes will score higher than someone doing mostly short sessions.': 'Chi si allena regolarmente per 90 minuti otterrà un punteggio più alto rispetto a chi fa soprattutto sessioni brevi.'
 Speed: Velocità
 'Speed distribution': 'Distribuzione della velocità'
 Splits: Intertempi
-'Sport variety': 'Sport variety'
+'Sport variety': 'Varietà sportiva'
 Squash: Squash
 'Stair Stepper': 'Stepper a gradini'
 'Stand Up Paddling': 'Stand up paddle'
@@ -324,20 +324,20 @@ Squash: Squash
 'Statistics for Strava': 'Statistiche per Strava'
 'Stats per weekday': 'Statistiche giornaliere'
 Status: Status
-'Strava profile': 'Strava profile'
-'Streak started on {date}': 'Streak started on {date}'
+'Strava profile': 'Profilo Strava'
+'Streak started on {date}': 'Serie iniziata il {date}'
 Streaks: Serie
 Sun: Dom
 Sunday: Domenica
 Surfing: Surf
 Swim: Nuoto
 'TSB (Form)': 'TSB (Forma)'
-'TSB positive in': 'TSB positive in'
+'TSB positive in': 'TSB positivo tra'
 'Table Tennis': 'Tennis tavolo'
 Tag: Etichetta
 'Tag "{maintenanceTaskTag}" was used on "{activityName}", but the gear referenced on that activity is not attached to this component.': 'L''etichetta "{maintenanceTaskTag}" è stata usata su "{activityName}", ma l''attrezzatura associata a quell''attività non è collegata a questo componente.'
 'Taper sweet-spot (+15)': 'Zona ideale di tapering (+15)'
-'Team Sports': 'Team Sports'
+'Team Sports': 'Sport di squadra'
 Tennis: Tennis
 "That's 1.5 times the distance to the edge of space": "That's 1.5 times the distance to the edge of space"
 "That's 100 days of commitment, triple digits!": "That's 100 days of commitment, triple digits!"
@@ -429,7 +429,7 @@ Tennis: Tennis
 'The Eddington number in the context of cycling or running is defined as the maximum number E such that the athlete has covered at least E km on at least E days.': "Il numero di Eddington nel ciclismo o nella corsa è definito come il massimo numero E tale che l'atleta abbia percorso almeno E km in almeno E giorni."
 'These badges are dynamically created. You can use them in any &lt;img&gt; tag': 'Questi badge sono generati dinamicamente. Puoi usarli in qualsiasi tag &lt;img&gt;'
 Thinking...: Elaborazione...
-'This chart summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.': 'This chart summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.'
+'This chart summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.': 'Questo grafico riassume come ti alleni. Ogni asse riflette una diversa abitudine di allenamento normalizzata, quindi valori più alti indicano un’enfasi maggiore.'
 'This feature is currently disabled': 'Questa funzionalità è attualmente disattivata'
 Thu: Gio
 Thursday: Giovedì
@@ -445,13 +445,13 @@ Time: Tempo
 'Total hours spent per sport type': 'Ore totali per tipo di sport'
 'Total kudos and comments received': 'Totale di kudos e commenti ricevuti'
 'Trail Runs': 'Corse trail'
-'Training 4–5 days every week scores higher than doing everything in one or two days.': 'Training 4–5 days every week scores higher than doing everything in one or two days.'
+'Training 4–5 days every week scores higher than doing everything in one or two days.': 'Allenarsi 4–5 giorni ogni settimana ottiene un punteggio più alto rispetto a concentrare tutto in uno o due giorni.'
 'Training Impulse - Training load metric that accounts for intensity and duration.': 'Training Impulse - metrica del carico di allenamento che tiene conto di intensità e durata.'
 'Training Load Analysis': 'Analisi del carico di allenamento'
 'Training Monotony - Ratio of average daily load to standard deviation. Indicates training variety.': "Monotonia di allenamento - rapporto tra carico giornaliero medio e deviazione standard. Indica la varietà dell'allenamento."
 'Training Stress Balance (Form) – The difference between fitness (CTL) and fatigue (ATL). Reflects how ready you are to perform.': 'Training Stress Balance (Forma) – differenza tra forma (CTL) e fatica (ATL). Indica quanto sei pronto a rendere al meglio.'
-'Training goals': 'Training goals'
-'Training load is accumulating, recovery days are important': 'Training load is accumulating, recovery days are important'
+'Training goals': 'Obiettivi di allenamento'
+'Training load is accumulating, recovery days are important': 'Il carico di allenamento si sta accumulando, i giorni di recupero sono importanti'
 Tue: Mar
 Tuesday: Martedì
 Unspecified: 'Non specificato'
@@ -480,17 +480,17 @@ Weekly: Weekly
 'Weekly stats': 'Statistiche settimanali'
 Weight: Weight
 'Weight Training': 'Allenamento con i pesi'
-'Weight history': 'Weight history'
+'Weight history': 'Storico peso'
 Wheelchair: 'Sedia a rotelle'
 'Wind Surf': Windsurf
 'Winter Sports': 'Sport invernali'
 Workout: Allenamento
-'Workout assistant': 'Workout assistant'
+'Workout assistant': 'Assistente allenamento'
 'Workout type': 'Tipo di allenamento'
 YTD: YTD
 Year: Anno
 Yearly: Yearly
-'Yearly stats': 'Yearly stats'
+'Yearly stats': 'Statistiche annuali'
 Yoga: Yoga
 "You recorded workouts in {numberOfCountriesWithWorkouts} different countries, that's {percentage} of all countries 🌍": 'Hai registrato allenamenti in {numberOfCountriesWithWorkouts} paesi diversi, pari al {percentage} di tutti i paesi 🌍'
 'Your PB badge': 'Il tuo badge record personale'
@@ -508,10 +508,10 @@ Yoga: Yoga
 'Zone 5 (maximal)': 'Zona 5 (massimale)'
 'Zwift Statistics': 'Statistiche Zwift'
 'Zwift badge': 'Badge Zwift'
-'Zwift stats': 'Zwift stats'
+'Zwift stats': 'Statistiche Zwift'
 activities: attività
 and: e
-'average gradient': 'average gradient'
+'average gradient': 'pendenza media'
 avg: media
 bpm: bpm
 clear: pulisci
@@ -534,24 +534,24 @@ n/a: n/d
 never: mai
 'on': il
 per: per
-'per activity': 'per activity'
-'per hour': 'per hour'
-'reached Eddington number {number}': 'reached Eddington number {number}'
+'per activity': 'per attività'
+'per hour': 'per ora'
+'reached Eddington number {number}': 'raggiunto numero di Eddington {number}'
 to: a
 total: totale
 weeks: settimane
 workouts: allenamenti
 '{daysSinceLastTagged} days': '{daysSinceLastTagged} giorni'
-'{days} consecutive days of activity': '{days} consecutive days of activity'
+'{days} consecutive days of activity': '{days} giorni consecutivi di attività'
 '{hoursSinceLastTagged} hours': '{hoursSinceLastTagged} ore'
 '{maintenanceTaskLabel} every {interval}': '{maintenanceTaskLabel} ogni {interval}'
 '{numberOfActivities} activities': '{numberOfActivities} attività'
 '{numberOfActivities} activities in {year}': '{numberOfActivities} attività nel {year}'
-'{numberOfMonths} months': '{numberOfMonths} months'
-'{numberOfResults} photos based on your active filters': '{numberOfResults} photos based on your active filters'
+'{numberOfMonths} months': '{numberOfMonths} mesi'
+'{numberOfResults} photos based on your active filters': '{numberOfResults} foto in base ai filtri attivi'
 '{numberOfResults} results based on your active filters': '{numberOfResults} risultati in base ai filtri attivi'
 '{numberOfResults} routes based on your active filters': '{numberOfResults} percorsi in base ai filtri attivi'
-'{numberOfWeeks} weeks': '{numberOfWeeks} weeks'
-'{threshold} hours using {gearName}': '{threshold} hours using {gearName}'
-'{threshold} total distance using {gearName}': '{threshold} total distance using {gearName}'
-'{threshold} total elevation using {gearName}': '{threshold} total elevation using {gearName}'
+'{numberOfWeeks} weeks': '{numberOfWeeks} settimane'
+'{threshold} hours using {gearName}': '{threshold} ore usando {gearName}'
+'{threshold} total distance using {gearName}': '{threshold} distanza totale usando {gearName}'
+'{threshold} total elevation using {gearName}': '{threshold} dislivello totale usando {gearName}'


### PR DESCRIPTION
## Summary
- improve the first pass of Italian translations in translations/messages+intl-icu.it_IT.yaml
- translate a batch of remaining English UI labels and help text
- keep the change scoped to Italian locale improvements only

Fixes #1935
