### PR TITLE
Add Hiking as a separate ActivityType from Walking

### DIFF
--- a/src/Application/Import/CalculateActivityMetrics/Pipeline/CalculateCombinedStreams.php
+++ b/src/Application/Import/CalculateActivityMetrics/Pipeline/CalculateCombinedStreams.php
@@ -95,7 +95,7 @@ final readonly class CalculateCombinedStreams implements CalculateActivityMetric
                     // Smoothen the power stream to remove noise and have a smooth line.
                     $stream = $stream->applySimpleMovingAverage(3);
                 }
-                if (in_array($activity->getSportType()->getActivityType(), [ActivityType::RUN, ActivityType::WALK])
+                if (in_array($activity->getSportType()->getActivityType(), [ActivityType::RUN, ActivityType::WALK, ActivityType::HIKE])
                     && StreamType::VELOCITY === $stream->getStreamType()) {
                     // Smoothen the velocity stream to remove peaks in velocity due to GPS issues.
                     $stream = $stream->applySimpleMovingAverage(15);

--- a/src/Domain/Activity/ActivityType.php
+++ b/src/Domain/Activity/ActivityType.php
@@ -17,6 +17,7 @@ enum ActivityType: string implements TranslatableInterface
     case RIDE = 'Ride';
     case RUN = 'Run';
     case WALK = 'Walk';
+    case HIKE = 'Hike';
     case WATER_SPORTS = 'WaterSports';
     case WINTER_SPORTS = 'WinterSports';
     case SKATING = 'Skating';
@@ -48,6 +49,7 @@ enum ActivityType: string implements TranslatableInterface
             self::RIDE => $translator->trans('Cycling', locale: $locale),
             self::RUN => $translator->trans('Running', locale: $locale),
             self::WALK => $translator->trans('Walking', locale: $locale),
+            self::HIKE => $translator->trans('Hiking', locale: $locale),
             self::WATER_SPORTS => $translator->trans('Water Sports', locale: $locale),
             self::WINTER_SPORTS => $translator->trans('Winter Sports', locale: $locale),
             self::SKATING => $translator->trans('Skating', locale: $locale),
@@ -77,7 +79,7 @@ enum ActivityType: string implements TranslatableInterface
     public function supportsDistanceBreakdownStats(): bool
     {
         return match ($this) {
-            self::RUN, self::RIDE, self::WALK, self::SKATING => true,
+            self::RUN, self::RIDE, self::WALK, self::HIKE, self::SKATING => true,
             default => false,
         };
     }
@@ -85,7 +87,7 @@ enum ActivityType: string implements TranslatableInterface
     public function supportsDistanceAndElevation(): bool
     {
         return match ($this) {
-            self::RUN, self::RIDE, self::WALK, self::WATER_SPORTS, self::SKATING => true,
+            self::RUN, self::RIDE, self::WALK, self::HIKE, self::WATER_SPORTS, self::SKATING => true,
             default => false,
         };
     }
@@ -140,7 +142,7 @@ enum ActivityType: string implements TranslatableInterface
     public function getDistancePrecision(): int
     {
         return match ($this) {
-            self::RIDE, self::RUN, self::WALK, self::WATER_SPORTS => 2,
+            self::RIDE, self::RUN, self::WALK, self::HIKE, self::WATER_SPORTS => 2,
             default => 0,
         };
     }
@@ -151,6 +153,7 @@ enum ActivityType: string implements TranslatableInterface
             ActivityType::RIDE => 'emerald-600',
             ActivityType::RUN => 'orange-500',
             ActivityType::WALK => 'yellow-300',
+            ActivityType::HIKE => 'green-600',
             ActivityType::WATER_SPORTS => 'blue-600',
             ActivityType::WINTER_SPORTS => 'red-600',
             default => 'gray-600',

--- a/src/Domain/Activity/Eddington/Config/EddingtonConfiguration.php
+++ b/src/Domain/Activity/Eddington/Config/EddingtonConfiguration.php
@@ -40,7 +40,13 @@ final class EddingtonConfiguration extends Collection
             [
                 'label' => 'Walk',
                 'showInNavBar' => false,
-                'sportTypesToInclude' => ['Walk', 'Hike'],
+                'sportTypesToInclude' => ['Walk'],
+                'showInDashboardWidget' => false,
+            ],
+            [
+                'label' => 'Hike',
+                'showInNavBar' => false,
+                'sportTypesToInclude' => ['Hike'],
                 'showInDashboardWidget' => false,
             ],
         ];

--- a/src/Domain/Activity/SportType/SportType.php
+++ b/src/Domain/Activity/SportType/SportType.php
@@ -26,8 +26,9 @@ enum SportType: string implements TranslatableInterface
     case RUN = 'Run';
     case TRAIL_RUN = 'TrailRun';
     case VIRTUAL_RUN = 'VirtualRun';
-    // Walk
+    // Walk.
     case WALK = 'Walk';
+    // Hike.
     case HIKE = 'Hike';
     // Water sports.
     case CANOEING = 'Canoeing';
@@ -84,7 +85,7 @@ enum SportType: string implements TranslatableInterface
 
     public function getVelocityDisplayPreference(): Velocity
     {
-        if (ActivityType::RUN === self::getActivityType() || ActivityType::WALK === self::getActivityType()) {
+        if (in_array(self::getActivityType(), [ActivityType::RUN, ActivityType::WALK, ActivityType::HIKE])) {
             return SecPerKm::zero();
         }
 
@@ -96,7 +97,7 @@ enum SportType: string implements TranslatableInterface
 
     public function getTemplateName(): string
     {
-        if (ActivityType::RUN === self::getActivityType() || ActivityType::WALK === self::getActivityType()) {
+        if (in_array(self::getActivityType(), [ActivityType::RUN, ActivityType::WALK, ActivityType::HIKE])) {
             return 'activity--sport-type--run';
         }
 
@@ -178,7 +179,9 @@ enum SportType: string implements TranslatableInterface
             // RUN.
             SportType::RUN, SportType::TRAIL_RUN, SportType::VIRTUAL_RUN => ActivityType::RUN,
             // WALK.
-            SportType::WALK, SportType::HIKE => ActivityType::WALK,
+            SportType::WALK => ActivityType::WALK,
+            // HIKE.
+            SportType::HIKE => ActivityType::HIKE,
             // WATER.
             SportType::CANOEING, SportType::KAYAKING, SportType::KITE_SURF,
             SportType::ROWING, SportType::STAND_UP_PADDLING,

--- a/src/Domain/Activity/Stream/CombinedStream/CombinedStreamTypes.php
+++ b/src/Domain/Activity/Stream/CombinedStream/CombinedStreamTypes.php
@@ -19,7 +19,7 @@ final class CombinedStreamTypes extends Collection
 
     public static function othersFor(ActivityType $activityType): self
     {
-        if (in_array($activityType, [ActivityType::RUN, ActivityType::WALK])) {
+        if (in_array($activityType, [ActivityType::RUN, ActivityType::WALK, ActivityType::HIKE])) {
             return self::fromArray([
                 CombinedStreamType::ALTITUDE,
                 CombinedStreamType::HEART_RATE,

--- a/tests/Domain/Activity/Eddington/Config/EddingtonConfigurationTest.php
+++ b/tests/Domain/Activity/Eddington/Config/EddingtonConfigurationTest.php
@@ -35,7 +35,15 @@ class EddingtonConfigurationTest extends TestCase
                 label: 'Walk',
                 showInNavBar: false,
                 sportTypesToInclude: SportTypes::fromArray([
-                    SportType::WALK, SportType::HIKE,
+                    SportType::WALK,
+                ]),
+                showInDashboardWidget: false,
+            ),
+            EddingtonConfigItem::create(
+                label: 'Hike',
+                showInNavBar: false,
+                sportTypesToInclude: SportTypes::fromArray([
+                    SportType::HIKE,
                 ]),
                 showInDashboardWidget: false,
             ),
@@ -131,7 +139,13 @@ class EddingtonConfigurationTest extends TestCase
             [
                 'label' => 'Walk',
                 'showInNavBar' => false,
-                'sportTypesToInclude' => ['Walk', 'Hike'],
+                'sportTypesToInclude' => ['Walk'],
+                'showInDashboardWidget' => false,
+            ],
+            [
+                'label' => 'Hike',
+                'showInNavBar' => false,
+                'sportTypesToInclude' => ['Hike'],
                 'showInDashboardWidget' => false,
             ],
         ];


### PR DESCRIPTION
Hike was previously grouped under ActivityType::WALK, which lumped hiking data with walking data across the dashboard (heart rate zones, monthly stats, weekly stats, yearly stats, etc.). This separates Hiking into its own first-class ActivityType so it gets its own tabs and charts everywhere.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Translations
- [ ] Documentation Update

## Description

Fixes ISSUE_NUMBER
