### PR TITLE
Add Hungarian (hu_HU) translation

### DIFF
--- a/docs/configuration/config-yaml-example.md
+++ b/docs/configuration/config-yaml-example.md
@@ -67,7 +67,7 @@ general:
       cycling: []
       running: []
 appearance:
-  # Allowed options: en_US, fr_FR, it_IT, nl_BE, de_DE, pt_BR, pt_PT sv_SE or zh_CN
+  # Allowed options: en_US, fr_FR, hu_HU, it_IT, nl_BE, de_DE, pt_BR, pt_PT sv_SE or zh_CN
   locale: 'en_US'
   # Allowed options: metric or imperial
   unitSystem: 'metric'

--- a/docs/development/locales-and-translations.md
+++ b/docs/development/locales-and-translations.md
@@ -6,6 +6,7 @@ Currently, the app is translated to:
 * 🇫🇷 French (thanks to [@llaumgui](https://github.com/llaumgui), [@Ahmosys](https://github.com/llaumgui) and [@Snoopfr](https://github.com/Snoopfr))
 * 🇩🇪 German (thanks to [@daydreamer77](https://github.com/daydreamer77))
 * 🇧🇪 Dutch
+* 🇭🇺 Hungarian (thanks to [@czdanika](https://github.com/czdanika))
 * 🇮🇹 Italian (thanks to Highlander)
 * 🇵🇹 Portuguese (thanks to [@jcnmsg](https://github.com/jcnmsg), [@davisenra](https://github.com/davisenra) & Batista)
 * 🇸🇪 Swedish  (thanks to [@strobit](https://github.com/strobit))

--- a/src/Infrastructure/Localisation/Locale.php
+++ b/src/Infrastructure/Localisation/Locale.php
@@ -9,11 +9,11 @@ enum Locale: string
     case de_DE = 'de_DE';
     case en_US = 'en_US';
     case fr_FR = 'fr_FR';
+    case hu_HU = 'hu_HU';
     case it_IT = 'it_IT';
     case nl_BE = 'nl_BE';
     case pt_BR = 'pt_BR';
     case pt_PT = 'pt_PT';
     case sv_SV = 'sv_SE';
     case zh_CN = 'zh_CN';
-    case hu_HU = 'hu_HU';
 }

--- a/src/Infrastructure/Localisation/Locale.php
+++ b/src/Infrastructure/Localisation/Locale.php
@@ -15,4 +15,5 @@ enum Locale: string
     case pt_PT = 'pt_PT';
     case sv_SV = 'sv_SE';
     case zh_CN = 'zh_CN';
+    case hu_HU = 'hu_HU';
 }

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--3c64bce0-4f00-54bc-a9fb-a2402a364b87-html-hu_HU.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--3c64bce0-4f00-54bc-a9fb-a2402a364b87-html-hu_HU.html
@@ -1,0 +1,30 @@
+<html><body>
+<div class="rainbow-bg text-[#111827] flex items-center justify-center min-h-[80vh] relative overflow-hidden">
+    <div class="text-center px-6 relative z-10">
+        <div class="text-7xl my-4 animate-bounce">&eth;&#159;&yen;&#154;</div>
+        <div class="flex justify-center gap-4 text-4xl mb-6">
+            <span class="animate-spin">&eth;&#159;&#154;&acute;</span>
+            <span class="animate-spin [animation-direction:reverse]">&eth;&#159;&#143;&#131;</span>
+            <span class="animate-[spin_2s_linear_infinite]">&acirc;&#154;&frac12;</span>
+            <span class="animate-[spin_3s_linear_infinite_reverse]">&eth;&#159;&#143;&#138;</span>
+            <span class="animate-[spin_1.5s_linear_infinite]">&eth;&#159;&#143;&#139;&iuml;&cedil;&#143;</span>
+        </div>
+        <h1 class="text-2xl font-extrabold mb-3">
+            You found the easter egg!
+        </h1>
+        <p class="leading-relaxed max-w-md mx-auto">
+            No extra stats here. No secret dashboard.<br>
+            Just the knowledge that you cared enough<br>
+            to dig through the source code.<br><br>
+            Now close this tab and go break a sweat.
+        </p>
+        <div class="flex justify-center gap-4 text-4xl mt-6">
+            <span class="animate-[spin_1.5s_linear_infinite]">&eth;&#159;&#143;&#140;&iuml;&cedil;&#143;&acirc;&#128;&#141;&acirc;&#153;&#128;&iuml;&cedil;&#143;</span>
+            <span class="animate-[spin_3s_linear_infinite_reverse]">&acirc;&#155;&middot;&iuml;&cedil;&#143;</span>
+            <span class="animate-[spin_2s_linear_infinite]">&eth;&#159;&#143;&#132;</span>
+            <span class="animate-spin [animation-direction:reverse]">&acirc;&#155;&sup1;&iuml;&cedil;&#143;&acirc;&#128;&#141;&acirc;&#153;&#130;&iuml;&cedil;&#143;</span>
+            <span class="animate-spin">&eth;&#159;&yen;&#138;</span>
+        </div>
+    </div>
+</div>
+</body></html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Strava statisztik&Atilde;&iexcl;k | Robin Ingelbrecht</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="theme-color" content="#F26822">
+    <meta name="mobile-web-app-title" content="Strava statisztik&Atilde;&iexcl;k | Robin Ingelbrecht">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-title" content="Strava statisztik&Atilde;&iexcl;k">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/manifest/icon-apple-180.maskable.png">
+    <link href="/manifest.json?0025176c-5652-11ee-923d-02424dd627d5" rel="manifest" crossorigin="use-credentials">
+    <link rel="icon" type="image/x-icon" href="/assets/images/logo.svg">
+    <script>
+        document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'light');
+        if (localStorage.getItem('sideNavCollapsed') === 'true') {
+            document.documentElement.setAttribute('data-sidebar-collapsed', '');
+        }
+    </script>
+    <link href="/css/dist/tailwind.min.css?0025176c-5652-11ee-923d-02424dd627d5" rel="stylesheet">
+    <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+</head>
+<body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
+<div class="antialiased">
+    <!-- NAVIGATION -->
+            <nav class="text-gray-900 bg-white border-b border-gray-200 px-4 py-2.5 fixed left-0 right-0 top-0 z-1100 group">
+    <div class="flex flex-wrap justify-between items-center">
+        <div class="flex justify-start items-center">
+            <a id="toggle-sidebar-collapsed-state" class="p-2 mr-1 text-gray-600 rounded-lg cursor-pointer hidden md:block hover:text-gray-900 hover:bg-gray-100 focus:bg-gray-100 focus:ring-2 focus:ring-gray-100">
+                <svg class="sidebar-collapsed:hidden w-5 h-5" viewbox="0 -960 960 960" fill="currentColor"><path d="M660-368v-224q0-14-12-19t-22 5l-98 98q-12 12-12 28t12 28l98 98q10 10 22 5t12-19ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm120-80v-560H200v560h120Zm80 0h360v-560H400v560Zm-80 0H200h120Z"></path></svg>
+                <svg class="sidebar-collapsed:block hidden w-5 h-5" viewbox="0 -960 960 960" fill="currentColor"><path d="M500-592v224q0 14 12 19t22-5l98-98q12-12 12-28t-12-28l-98-98q-10-10-22-5t-12 19ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm120-80v-560H200v560h120Zm80 0h360v-560H400v560Zm-80 0H200h120Z"></path></svg>
+                <span class="sr-only">Oldals&Atilde;&iexcl;v &Atilde;&para;sszecsuk&Atilde;&iexcl;sa</span>
+            </a>
+            <button data-drawer-target="drawer-navigation" data-drawer-toggle="drawer-navigation" aria-controls="drawer-navigation" class="p-2 mr-2 text-gray-600 rounded-lg cursor-pointer md:hidden hover:text-gray-900 hover:bg-gray-100 focus:bg-gray-100 focus:ring-2 focus:ring-gray-100">
+                <svg aria-hidden="true" class="w-6 h-6" fill="currentColor" viewbox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path>
+                </svg>
+                <svg aria-hidden="true" class="hidden w-6 h-6" fill="currentColor" viewbox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                </svg>
+                <span class="sr-only">Oldals&Atilde;&iexcl;v ki/be</span>
+            </button>
+            <a href="#" data-router-navigate="/dashboard" class="flex items-center justify-between mr-4">
+                <img src="/assets/images/logo.svg" class="rounded-full mr-3 h-8" alt="Statistics for Strava Logo">
+                <div class="flex gap-x-1 sm:text-lg md:text-2xl font-semibold whitespace-nowrap">
+                    <div>Strava statisztik&Atilde;&iexcl;k</div>
+                                            <div class="hidden md:block">|</div>
+                        <div class="hidden md:block">Robin The King &eth;&#159;&#145;&#145;</div>
+                                    </div>
+            </a>
+        </div>
+        <div class="flex items-center text-gray-500 lg:order-2 gap-x-2">
+            <div class="hidden md:flex items-center">
+                <a href="https://buymeacoffee.com/ingelbrecht" target="_blank" title="Buy me a coffee" class="p-1 rounded-sm hover:bg-gray-100 group/menu-item">
+                    <svg class="w-7 h-6" viewbox="0 0 884 1279" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path class="y-path group-hover/menu-item:fill-[#FFDD04]" d="M472.623 590.836C426.682 610.503 374.546 632.802 306.976 632.802C278.71 632.746 250.58 628.868 223.353 621.274L270.086 1101.08C271.74 1121.13 280.876 1139.83 295.679 1153.46C310.482 1167.09 329.87 1174.65 349.992 1174.65C349.992 1174.65 416.254 1178.09 438.365 1178.09C462.161 1178.09 533.516 1174.65 533.516 1174.65C553.636 1174.65 573.019 1167.08 587.819 1153.45C602.619 1139.82 611.752 1121.13 613.406 1101.08L663.459 570.876C641.091 563.237 618.516 558.161 593.068 558.161C549.054 558.144 513.591 573.303 472.623 590.836Z" fill="currentColor"></path>
+                        <path fill="currentColor" class="group-hover/menu-item:fill-gray-900" d="M879.567 341.849L872.53 306.352C866.215 274.503 851.882 244.409 819.19 232.898C808.711 229.215 796.821 227.633 788.786 220.01C780.751 212.388 778.376 200.55 776.518 189.572C773.076 169.423 769.842 149.257 766.314 129.143C763.269 111.85 760.86 92.4243 752.928 76.56C742.604 55.2584 721.182 42.8009 699.88 34.559C688.965 30.4844 677.826 27.0375 666.517 24.2352C613.297 10.1947 557.342 5.03277 502.591 2.09047C436.875 -1.53577 370.983 -0.443234 305.422 5.35968C256.625 9.79894 205.229 15.1674 158.858 32.0469C141.91 38.224 124.445 45.6399 111.558 58.7341C95.7448 74.8221 90.5829 99.7026 102.128 119.765C110.336 134.012 124.239 144.078 138.985 150.737C158.192 159.317 178.251 165.846 198.829 170.215C256.126 182.879 315.471 187.851 374.007 189.968C438.887 192.586 503.87 190.464 568.44 183.618C584.408 181.863 600.347 179.758 616.257 177.304C634.995 174.43 647.022 149.928 641.499 132.859C634.891 112.453 617.134 104.538 597.055 107.618C594.095 108.082 591.153 108.512 588.193 108.942L586.06 109.252C579.257 110.113 572.455 110.915 565.653 111.661C551.601 113.175 537.515 114.414 523.394 115.378C491.768 117.58 460.057 118.595 428.363 118.647C397.219 118.647 366.058 117.769 334.983 115.722C320.805 114.793 306.661 113.611 292.552 112.177C286.134 111.506 279.733 110.801 273.333 110.009L267.241 109.235L265.917 109.046L259.602 108.134C246.697 106.189 233.792 103.953 221.025 101.251C219.737 100.965 218.584 100.249 217.758 99.2193C216.932 98.1901 216.482 96.9099 216.482 95.5903C216.482 94.2706 216.932 92.9904 217.758 91.9612C218.584 90.9319 219.737 90.2152 221.025 89.9293H221.266C232.33 87.5721 243.479 85.5589 254.663 83.8038C258.392 83.2188 262.131 82.6453 265.882 82.0832H265.985C272.988 81.6186 280.026 80.3625 286.994 79.5366C347.624 73.2301 408.614 71.0801 469.538 73.1014C499.115 73.9618 528.676 75.6996 558.116 78.6935C564.448 79.3474 570.746 80.0357 577.043 80.8099C579.452 81.1025 581.878 81.4465 584.305 81.7391L589.191 82.4445C603.438 84.5667 617.61 87.1419 631.708 90.1703C652.597 94.7128 679.422 96.1925 688.713 119.077C691.673 126.338 693.015 134.408 694.649 142.03L696.732 151.752C696.786 151.926 696.826 152.105 696.852 152.285C701.773 175.227 706.7 198.169 711.632 221.111C711.994 222.806 712.002 224.557 711.657 226.255C711.312 227.954 710.621 229.562 709.626 230.982C708.632 232.401 707.355 233.6 705.877 234.504C704.398 235.408 702.75 235.997 701.033 236.236H700.895L697.884 236.649L694.908 237.044C685.478 238.272 676.038 239.419 666.586 240.486C647.968 242.608 629.322 244.443 610.648 245.992C573.539 249.077 536.356 251.102 499.098 252.066C480.114 252.57 461.135 252.806 442.162 252.771C366.643 252.712 291.189 248.322 216.173 239.625C208.051 238.662 199.93 237.629 191.808 236.58C198.106 237.389 187.231 235.96 185.029 235.651C179.867 234.928 174.705 234.177 169.543 233.397C152.216 230.798 134.993 227.598 117.7 224.793C96.7944 221.352 76.8005 223.073 57.8906 233.397C42.3685 241.891 29.8055 254.916 21.8776 270.735C13.7217 287.597 11.2956 305.956 7.64786 324.075C4.00009 342.193 -1.67805 361.688 0.472751 380.288C5.10128 420.431 33.165 453.054 73.5313 460.35C111.506 467.232 149.687 472.807 187.971 477.556C338.361 495.975 490.294 498.178 641.155 484.129C653.44 482.982 665.708 481.732 677.959 480.378C681.786 479.958 685.658 480.398 689.292 481.668C692.926 482.938 696.23 485.005 698.962 487.717C701.694 490.429 703.784 493.718 705.08 497.342C706.377 500.967 706.846 504.836 706.453 508.665L702.633 545.797C694.936 620.828 687.239 695.854 679.542 770.874C671.513 849.657 663.431 928.434 655.298 1007.2C653.004 1029.39 650.71 1051.57 648.416 1073.74C646.213 1095.58 645.904 1118.1 641.757 1139.68C635.218 1173.61 612.248 1194.45 578.73 1202.07C548.022 1209.06 516.652 1212.73 485.161 1213.01C450.249 1213.2 415.355 1211.65 380.443 1211.84C343.173 1212.05 297.525 1208.61 268.756 1180.87C243.479 1156.51 239.986 1118.36 236.545 1085.37C231.957 1041.7 227.409 998.039 222.9 954.381L197.607 711.615L181.244 554.538C180.968 551.94 180.693 549.376 180.435 546.76C178.473 528.023 165.207 509.681 144.301 510.627C126.407 511.418 106.069 526.629 108.168 546.76L120.298 663.214L145.385 904.104C152.532 972.528 159.661 1040.96 166.773 1109.41C168.15 1122.52 169.44 1135.67 170.885 1148.78C178.749 1220.43 233.465 1259.04 301.224 1269.91C340.799 1276.28 381.337 1277.59 421.497 1278.24C472.979 1279.07 524.977 1281.05 575.615 1271.72C650.653 1257.95 706.952 1207.85 714.987 1130.13C717.282 1107.69 719.576 1085.25 721.87 1062.8C729.498 988.559 737.115 914.313 744.72 840.061L769.601 597.451L781.009 486.263C781.577 480.749 783.905 475.565 787.649 471.478C791.392 467.391 796.352 464.617 801.794 463.567C823.25 459.386 843.761 452.245 859.023 435.916C883.318 409.918 888.153 376.021 879.567 341.849ZM72.4301 365.835C72.757 365.68 72.1548 368.484 71.8967 369.792C71.8451 367.813 71.9483 366.058 72.4301 365.835ZM74.5121 381.94C74.6842 381.819 75.2003 382.508 75.7337 383.334C74.925 382.576 74.4089 382.009 74.4949 381.94H74.5121ZM76.5597 384.641C77.2996 385.897 77.6953 386.689 76.5597 384.641V384.641ZM80.672 387.979H80.7752C80.7752 388.1 80.9645 388.22 81.0333 388.341C80.9192 388.208 80.7925 388.087 80.6548 387.979H80.672ZM800.796 382.989C793.088 390.319 781.473 393.726 769.996 395.43C641.292 414.529 510.713 424.199 380.597 419.932C287.476 416.749 195.336 406.407 103.144 393.382C94.1102 392.109 84.3197 390.457 78.1082 383.798C66.4078 371.237 72.1548 345.944 75.2003 330.768C77.9878 316.865 83.3218 298.334 99.8572 296.355C125.667 293.327 155.64 304.218 181.175 308.09C211.917 312.781 242.774 316.538 273.745 319.36C405.925 331.405 540.325 329.529 671.92 311.91C695.906 308.686 719.805 304.941 743.619 300.674C764.835 296.871 788.356 289.731 801.175 311.703C809.967 326.673 811.137 346.701 809.778 363.615C809.359 370.984 806.139 377.915 800.779 382.989H800.796Z"></path>
+                    </svg>
+                </a>
+                <a target="_blank" title="Discord" href="https://discord.gg/p4zpZyCHNc" class="p-1 rounded-sm hover:bg-gray-100 hover:text-[#5865F4]">
+                    <svg class="w-7 h-7" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewbox="0 0 24 24">
+                        <path d="M18.942 5.556a16.3 16.3 0 0 0-4.126-1.3 12.04 12.04 0 0 0-.529 1.1 15.175 15.175 0 0 0-4.573 0 11.586 11.586 0 0 0-.535-1.1 16.274 16.274 0 0 0-4.129 1.3 17.392 17.392 0 0 0-2.868 11.662 15.785 15.785 0 0 0 4.963 2.521c.41-.564.773-1.16 1.084-1.785a10.638 10.638 0 0 1-1.706-.83c.143-.106.283-.217.418-.331a11.664 11.664 0 0 0 10.118 0c.137.114.277.225.418.331-.544.328-1.116.606-1.71.832a12.58 12.58 0 0 0 1.084 1.785 16.46 16.46 0 0 0 5.064-2.595 17.286 17.286 0 0 0-2.973-11.59ZM8.678 14.813a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.918 1.918 0 0 1 1.8 2.047 1.929 1.929 0 0 1-1.8 2.045Zm6.644 0a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.919 1.919 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Z"></path>
+                    </svg>
+                </a>
+                <a target="_blank" title="GitHub" href="https://github.com/robiningelbrecht/statistics-for-strava" class="p-1 rounded-sm hover:bg-gray-100 hover:text-gray-900">
+                    <svg class="w-7 h-7" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewbox="0 0 24 24">
+                        <path fill-rule="evenodd" d="M12.006 2a9.847 9.847 0 0 0-6.484 2.44 10.32 10.32 0 0 0-3.393 6.17 10.48 10.48 0 0 0 1.317 6.955 10.045 10.045 0 0 0 5.4 4.418c.504.095.683-.223.683-.494 0-.245-.01-1.052-.014-1.908-2.78.62-3.366-1.21-3.366-1.21a2.711 2.711 0 0 0-1.11-1.5c-.907-.637.07-.621.07-.621.317.044.62.163.885.346.266.183.487.426.647.71.135.253.318.476.538.655a2.079 2.079 0 0 0 2.37.196c.045-.52.27-1.006.635-1.37-2.219-.259-4.554-1.138-4.554-5.07a4.022 4.022 0 0 1 1.031-2.75 3.77 3.77 0 0 1 .096-2.713s.839-.275 2.749 1.05a9.26 9.26 0 0 1 5.004 0c1.906-1.325 2.74-1.05 2.74-1.05.37.858.406 1.828.101 2.713a4.017 4.017 0 0 1 1.029 2.75c0 3.939-2.339 4.805-4.564 5.058a2.471 2.471 0 0 1 .679 1.897c0 1.372-.012 2.477-.012 2.814 0 .272.18.592.687.492a10.05 10.05 0 0 0 5.388-4.421 10.473 10.473 0 0 0 1.313-6.948 10.32 10.32 0 0 0-3.39-6.165A9.847 9.847 0 0 0 12.007 2Z" clip-rule="evenodd"></path>
+                    </svg>
+                </a>
+            </div>
+                            <button id="profileDropdownMenuButton" data-dropdown-toggle="profileDropdownMenu" class="cursor-pointer flex rounded-full border" type="button">
+                    <span class="sr-only">Open user menu</span>
+                                            <div class="size-8 shrink-0 rounded-full border flex items-center justify-center bg-strava-orange text-white text-xs p-1">
+                            R
+                        </div>
+                                    </button>
+                <div id="profileDropdownMenu" class="z-10 hidden bg-white border border-gray-200 rounded-lg shadow-lg w-72">
+                    <div class="p-2">
+                        <div class="flex items-center px-2.5 p-2 space-x-1.5 text-sm bg-gray-50 rounded-sm">
+                                                            <div class="size-8 shrink-0 rounded-full border flex items-center justify-center bg-strava-orange text-white text-xs p-1">
+                                    R
+                                </div>
+                                                        <div>
+                                <div class="font-medium text-gray-900">Robin Ingelbrecht</div>
+                            </div>
+                        </div>
+                    </div>
+                    <ul class="px-2 pb-2 text-sm text-body font-medium" aria-labelledby="profileDropdownMenuButton">
+                                                <li>
+                            <a href="#" data-model-content-url="/badge.html" class="inline-flex items-center w-full p-2 hover:bg-gray-50 rounded">
+                                <svg class="size-4 me-1.5" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 507.9 507.9" xml:space="preserve">
+                    <g stroke-width="0"></g>
+                                    <g stroke-linecap="round" stroke-linejoin="round"></g>
+                                    <g>
+                                        <g>
+                                            <g>
+                                                <path d="M465.7,96.55H324.9v-21.6c0-7.8-6.3-14.1-14.1-14.1H197.2c-7.8,0-14.1,6.3-14.1,14.1v21.6H42.3c-23.3,0-42.3,19-42.3,42.3 v265.9c0,23.3,19,42.3,42.3,42.3h423.3c23.3,0,42.3-19,42.3-42.3v-265.9C508,115.55,489,96.55,465.7,96.55z M296.7,89.05v32.1 h-85.4v-32.1H296.7z M465.7,418.85H42.3c-7.8,0-14.1-6.3-14.1-14.1v-265.9c0-7.8,6.3-14.1,14.1-14.1h140.8v10.5 c0,7.8,6.3,14.1,14.1,14.1h113.6c7.8,0,14.1-6.3,14.1-14.1v-10.5h140.7c7.8,0,14.1,6.3,14.1,14.1v265.9h0.1 C479.8,412.55,473.5,418.85,465.7,418.85z"></path>
+                                            </g>
+                                        </g>
+                                        <g>
+                                            <g>
+                                                <path d="M440.6,173.65H254c-7.8,0-14.1,6.3-14.1,14.1s6.3,14.1,14.1,14.1h186.6c7.8,0,14.1-6.3,14.1-14.1 S448.4,173.65,440.6,173.65z"></path>
+                                            </g>
+                                        </g>
+                                        <g>
+                                            <g>
+                                                <path d="M440.6,241.95H254c-7.8,0-14.1,6.3-14.1,14.1s6.3,14.1,14.1,14.1h186.6c7.8,0,14.1-6.3,14.1-14.1 C454.7,248.25,448.4,241.95,440.6,241.95z"></path>
+                                            </g>
+                                        </g>
+                                        <g>
+                                            <g>
+                                                <path d="M440.6,310.35H254c-7.8,0-14.1,6.3-14.1,14.1c0,7.8,6.3,14.1,14.1,14.1h186.6c7.8,0,14.1-6.3,14.1-14.1 S448.4,310.35,440.6,310.35z"></path>
+                                            </g>
+                                        </g>
+                                        <g>
+                                            <g>
+                                                <path d="M180.1,160.45H67.4c-7.8,0-14.1,6.3-14.1,14.1v130.5c0,7.8,6.3,14.1,14.1,14.1h112.7c7.8,0,14.1-6.3,14.1-14.1v-130.5 C194.2,166.85,187.9,160.45,180.1,160.45z M166,290.95H81.6v-102.2H166V290.95z"></path>
+                                            </g>
+                                        </g>
+                                        <g>
+                                            <g>
+                                                <path d="M180.1,354.85H67.4c-7.8,0-14.1,6.3-14.1,14.1c0,7.8,6.3,14.1,14.1,14.1h112.7c7.8,0,14.1-6.3,14.1-14.1 S187.9,354.85,180.1,354.85z"></path>
+                                            </g>
+                                        </g>
+                                    </g>
+                </svg>
+                                Kit&Aring;&plusmn;z&Aring;&#145;k
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.strava.com/athletes/100" target="_blank" class="inline-flex items-center w-full p-2 hover:bg-gray-50 rounded">
+                                <svg class="size-4 me-1.5" fill="currentColor" viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <g stroke-width="0"></g>
+                                    <g stroke-linecap="round" stroke-linejoin="round"></g>
+                                    <g>
+                                        <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"></path>
+                                    </g>
+                                </svg>
+                                Strava profil
+                            </a>
+                        </li>
+                        <li class="border-t border-gray-200 pt-1.5">
+                            <label for="darkModeToggle" class="dark-mode-toggle hover:bg-gray-50 rounded p-2 flex cursor-pointer items-center">
+                                <div class="inline-flex items-center">
+                                    <svg class="w-4 h-4 me-1.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 21a9 9 0 0 1-.5-17.986V3c-.354.966-.5 1.911-.5 3a9 9 0 0 0 9 9c.239 0 .254.018.488 0A9.004 9.004 0 0 1 12 21Z"></path></svg>
+                                    <span class="text-sm font-medium text-heading">S&Atilde;&para;t&Atilde;&copy;t m&Atilde;&sup3;d</span>
+                                </div>
+                                <input id="darkModeToggle" type="checkbox" value="" class="peer sr-only">
+                                <div class="ms-auto peer peer-checked:after:border-buffer relative h-5 w-9 rounded-full bg-gray-200 peer-checked:bg-gray-100 peer-focus:outline-none after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full"></div>
+                            </label>
+                        </li>
+                    </ul>
+                </div>
+                    </div>
+    </div>
+</nav>        <!-- SIDEBAR -->
+    <aside class="fixed top-0 left-0 w-64 sidebar-collapsed:w-32 h-screen pt-14 transition-transform -translate-x-full bg-white border-r border-gray-200 md:translate-x-0 z-1001" aria-label="Sidenav" id="drawer-navigation">
+                <div class="sidebar-collapsed:max-h-full max-h-[calc(100vh-114px)] overflow-y-auto py-5 px-3 h-full divide-y divide-gray-200">
+            <ul class="space-y-1 pb-2">
+                <li>
+                    <a href="/dashboard" data-router-navigate="/dashboard" class="sidebar-menu-link">
+                        <svg aria-hidden="true" class="sidebar-menu-link-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6.025A7.5 7.5 0 1 0 17.975 14H10V6.025Z"></path>
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 3c-.169 0-.334.014-.5.025V11h7.975c.011-.166.025-.331.025-.5A7.5 7.5 0 0 0 13.5 3Z"></path>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Ir&Atilde;&iexcl;ny&Atilde;&shy;t&Atilde;&sup3;pult</span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="space-y-1 py-2">
+                <li>
+                    <a href="/activities" data-router-navigate="/activities" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 9h6m-6 3h6m-6 3h6M6.996 9h.01m-.01 3h.01m-.01 3h.01M4 5h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z"></path>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Tev&Atilde;&copy;kenys&Atilde;&copy;gek</span>
+                        <span class="sidebar-collapsed:hidden badge-pill">15</span>
+                    </a>
+                </li>
+                                    <li>
+                        <a href="/gear" data-router-navigate="/gear" class="sidebar-menu-link">
+                            <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m10.051 8.102-3.778.322-1.994 1.994a.94.94 0 0 0 .533 1.6l2.698.316m8.39 1.617-.322 3.78-1.994 1.994a.94.94 0 0 1-1.595-.533l-.4-2.652m8.166-11.174a1.366 1.366 0 0 0-1.12-1.12c-1.616-.279-4.906-.623-6.38.853-1.671 1.672-5.211 8.015-6.31 10.023a.932.932 0 0 0 .162 1.111l.828.835.833.832a.932.932 0 0 0 1.111.163c2.008-1.102 8.35-4.642 10.021-6.312 1.475-1.478 1.133-4.77.855-6.385Zm-2.961 3.722a1.88 1.88 0 1 1-3.76 0 1.88 1.88 0 0 1 3.76 0Z"></path>
+                            </svg>
+                            <span class="flex-1 whitespace-nowrap">Felszerel&Atilde;&copy;s</span>
+                                                    </a>
+                    </li>
+                                <li>
+                    <a href="/segments" data-router-navigate="/segments" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" fill="currentColor" viewbox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                            <g stroke-width="0"></g>
+                            <g stroke-linecap="round" stroke-linejoin="round"></g>
+                            <g>
+                                <path d="M217.45557,38.544a35.9967,35.9967,0,0,0-57.937,40.96679L79.5105,159.51855a36.05906,36.05906,0,0,0-40.96607,7.0254H38.544a36.00029,36.00029,0,1,0,57.93737,9.94531L176.4895,96.48145A35.99663,35.99663,0,0,0,217.45557,38.544ZM72.48584,200.48535a12.00027,12.00027,0,0,1-16.97119-16.9707h-.00049a12.00044,12.00044,0,0,1,16.97168,16.9707Zm128-128a12.01673,12.01673,0,0,1-16.969.00244l-.0022-.00244a12.0001,12.0001,0,1,1,16.97119,0Z"></path>
+                            </g>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Szegmensek</span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="space-y-1 py-2">
+                <li>
+                    <a href="/monthly-stats" data-router-navigate="/monthly-stats" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z"></path>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Havi statisztik&Atilde;&iexcl;k</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/eddington" data-router-navigate="/eddington" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4.5V19a1 1 0 0 0 1 1h15M7 14l4-4 4 4 5-5m0 0h-3.207M20 9v3.207"></path>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Eddington</span>
+                        <div class="sidebar-collapsed:hidden flex gap-x-0.5">
+                                                            <span class="badge-pill">6</span>
+                                                            <span class="badge-pill">2</span>
+                                                    </div>
+                    </a>
+                </li>
+                <li>
+                    <a href="/heatmap" data-router-navigate="/heatmap" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" viewbox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <g stroke-width="0"></g>
+                            <g stroke-linecap="round" stroke-linejoin="round"></g>
+                            <g>
+                                <path d="M3 8.70938C3 7.23584 3 6.49907 3.39264 6.06935C3.53204 5.91678 3.70147 5.79466 3.89029 5.71066C4.42213 5.47406 5.12109 5.70705 6.51901 6.17302C7.58626 6.52877 8.11989 6.70665 8.6591 6.68823C8.85714 6.68147 9.05401 6.65511 9.24685 6.60952C9.77191 6.48541 10.2399 6.1734 11.176 5.54937L12.5583 4.62778C13.7574 3.82843 14.3569 3.42876 15.0451 3.3366C15.7333 3.24444 16.4168 3.47229 17.7839 3.92799L18.9487 4.31624C19.9387 4.64625 20.4337 4.81126 20.7169 5.20409C21 5.59692 21 6.11871 21 7.16229V15.2907C21 16.7642 21 17.501 20.6074 17.9307C20.468 18.0833 20.2985 18.2054 20.1097 18.2894C19.5779 18.526 18.8789 18.293 17.481 17.827C16.4137 17.4713 15.8801 17.2934 15.3409 17.3118C15.1429 17.3186 14.946 17.3449 14.7532 17.3905C14.2281 17.5146 13.7601 17.8266 12.824 18.4507L11.4417 19.3722C10.2426 20.1716 9.64311 20.5713 8.95493 20.6634C8.26674 20.7556 7.58319 20.5277 6.21609 20.072L5.05132 19.6838C4.06129 19.3538 3.56627 19.1888 3.28314 18.7959C3 18.4031 3 17.8813 3 16.8377V8.70938Z" stroke="currentColor" stroke-width="2"></path>
+                                <path d="M9 6.63867V20.5" stroke="currentColor" stroke-width="2"></path>
+                                <path d="M15 3V17" stroke="currentColor" stroke-width="2"></path>
+                            </g>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">H&Aring;&#145;t&Atilde;&copy;rk&Atilde;&copy;p</span>
+                    </a>
+                </li>
+                                    <li>
+                        <a href="/best-efforts" data-router-navigate="/best-efforts" class="sidebar-menu-link">
+                            <svg class="sidebar-menu-link-icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24">
+                                <path fill="currentColor" d="M21,4H18V3a1,1,0,0,0-1-1H7A1,1,0,0,0,6,3V4H3A1,1,0,0,0,2,5V8a4,4,0,0,0,4,4H7.54A6,6,0,0,0,11,13.91V16H10a3,3,0,0,0-3,3v2a1,1,0,0,0,1,1h8a1,1,0,0,0,1-1V19a3,3,0,0,0-3-3H13V13.91A6,6,0,0,0,16.46,12H18a4,4,0,0,0,4-4V5A1,1,0,0,0,21,4ZM6,10A2,2,0,0,1,4,8V6H6V8a6,6,0,0,0,.35,2Zm8,8a1,1,0,0,1,1,1v1H9V19a1,1,0,0,1,1-1ZM16,8A4,4,0,0,1,8,8V4h8Zm4,0a2,2,0,0,1-2,2h-.35A6,6,0,0,0,18,8V6h2Z"></path>
+                            </svg>
+                            <span class="flex-1 whitespace-nowrap">Legjobb teljes&Atilde;&shy;tm&Atilde;&copy;ny...</span>
+                        </a>
+                    </li>
+                                <li>
+                    <a href="/milestones" data-router-navigate="/milestones" class="sidebar-menu-link">
+
+                        <svg class="sidebar-menu-link-icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 -960 960 960" fill="currentColor"><path d="M80-200v-80h240v-240h240v-240h320v80H640v240H400v240H80Z"></path></svg>
+                        <span class="flex-1 whitespace-nowrap">M&Atilde;&copy;rf&Atilde;&para;ldk&Atilde;&para;vek</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="/rewind" data-router-navigate="/rewind" class="sidebar-menu-link">
+                        <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3M3.22302 14C4.13247 18.008 7.71683 21 12 21c4.9706 0 9-4.0294 9-9 0-4.97056-4.0294-9-9-9-3.72916 0-6.92858 2.26806-8.29409 5.5M7 9H3V5"></path>
+                        </svg>
+                        <span class="flex-1 whitespace-nowrap">Visszatekint&Aring;&#145;</span>
+                    </a>
+                </li>
+            </ul>
+                            <ul class="space-y-1 py-2">
+                                            <li>
+                            <a href="/challenges" data-router-navigate="/challenges" class="sidebar-menu-link">
+                                <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m8.032 12 1.984 1.984 4.96-4.96m4.55 5.272.893-.893a1.984 1.984 0 0 0 0-2.806l-.893-.893a1.984 1.984 0 0 1-.581-1.403V7.04a1.984 1.984 0 0 0-1.984-1.984h-1.262a1.983 1.983 0 0 1-1.403-.581l-.893-.893a1.984 1.984 0 0 0-2.806 0l-.893.893a1.984 1.984 0 0 1-1.403.581H7.04A1.984 1.984 0 0 0 5.055 7.04v1.262c0 .527-.209 1.031-.581 1.403l-.893.893a1.984 1.984 0 0 0 0 2.806l.893.893c.372.372.581.876.581 1.403v1.262a1.984 1.984 0 0 0 1.984 1.984h1.262c.527 0 1.031.209 1.403.581l.893.893a1.984 1.984 0 0 0 2.806 0l.893-.893a1.985 1.985 0 0 1 1.403-.581h1.262a1.984 1.984 0 0 0 1.984-1.984V15.7c0-.527.209-1.031.581-1.403Z"></path>
+                                </svg>
+                                <span class="flex-1 whitespace-nowrap">Kih&Atilde;&shy;v&Atilde;&iexcl;sok</span>
+                                <span class="sidebar-collapsed:hidden badge-pill">2</span>
+                            </a>
+                        </li>
+                                                                <li>
+                            <a href="/photos" data-router-navigate="/photos" class="sidebar-menu-link">
+                                <svg class="sidebar-menu-link-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewbox="0 0 24 24">
+                                    <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 18V8a1 1 0 0 1 1-1h1.5l1.707-1.707A1 1 0 0 1 8.914 5h6.172a1 1 0 0 1 .707.293L17.5 7H19a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Z"></path>
+                                    <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"></path>
+                                </svg>
+                                <span class="flex-1 whitespace-nowrap">Fot&Atilde;&sup3;k</span>
+                                <span class="sidebar-collapsed:hidden badge-pill">32</span>
+                            </a>
+                        </li>
+                                    </ul>
+                    </div>
+        <div class="border-t absolute p-2 flex flex-col gap-y-1 justify-center text-xs text-center text-gray-500 bottom-0 left-0 w-full bg-white z-20">
+            <div class="sidebar-collapsed:hidden">
+                <div class="flex items-center justify-center gap-x-1">
+                    <span class="bg-gray-100 text-gray-600 font-medium px-2.5 py-0.5 rounded-sm" title="Friss&Atilde;&shy;tve: 17-10-2023 16:15">v4.7.8</span>
+                    <span class="hidden" data-latest-version data-current-version="v4.7.8">
+                    (latest: <a class="underline" href="https://github.com/robiningelbrecht/statistics-for-strava/releases/tag/%5BLATEST_VERSION%5D">[LATEST_VERSION]</a>)
+                </span>
+                </div>
+            </div>
+            <div class="flex gap-x-1 items-center justify-center">
+                <img class="h-3" src="/assets/images/strava/powered-by-strava.svg" alt="Powered by Strava">
+                <div class="sidebar-collapsed:hidden">&amp; &acirc;&#152;&#149;</div>
+            </div>
+        </div>
+    </aside>
+    <!-- MAIN -->
+    <main class="p-4 md:ml-64 sidebar-collapsed:md:ml-32 h-auto min-h-screen pt-20 text-gray-900">
+                    <div id="spinner" class="items-center justify-center h-auto min-h-screen hidden">
+                <div role="status">
+                    <svg aria-hidden="true" class="w-8 h-8 mr-2 text-gray-200 animate-spin fill-orange-500" viewbox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"></path>
+                        <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"></path>
+                    </svg>
+                    <span class="sr-only">Bet&Atilde;&para;lt&Atilde;&copy;s...</span>
+                </div>
+            </div>
+            <!-- JS LOADED CONTENT -->
+            <div id="js-loaded-content"></div>
+            <div id="modal-skeleton" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-1500 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div class="relative p-4 w-full max-w-7xl max-h-full">
+                    <!-- Modal spinner -->
+                    <div class="spinner hidden p-4 items-center justify-center h-auto bg-white rounded-lg shadow-sm">
+                        <div role="status">
+                            <svg aria-hidden="true" class="w-8 h-8 mr-2 text-gray-200 animate-spin fill-orange-500" viewbox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"></path>
+                                <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"></path>
+                            </svg>
+                            <span class="sr-only">Bet&Atilde;&para;lt&Atilde;&copy;s...</span>
+                        </div>
+                    </div>
+                    <!-- Modal content -->
+                    <div id="modal-content" class="relative bg-white rounded-lg shadow-sm">
+
+                    </div>
+                </div>
+            </div>
+            </main>
+</div>
+<script>
+    window.statisticsForStrava = {"countries":{"AF":"Afganiszt\u00e1n","AX":"\u00c5land-szigetek","AL":"Alb\u00e1nia","DZ":"Alg\u00e9ria","AS":"Amerikai Szamoa","VI":"Amerikai Virgin-szigetek","AD":"Andorra","AO":"Angola","AI":"Anguilla","AQ":"Antarktisz","AG":"Antigua \u00e9s Barbuda","AR":"Argent\u00edna","AW":"Aruba","AU":"Ausztr\u00e1lia","AT":"Ausztria","UM":"Az USA lakatlan k\u00fclbirtokai","AZ":"Azerbajdzs\u00e1n","BS":"Bahama-szigetek","BH":"Bahrein","BD":"Banglades","BB":"Barbados","BY":"Belarusz","BE":"Belgium","BZ":"Belize","BJ":"Benin","BM":"Bermuda","BT":"Bhut\u00e1n","GW":"Bissau-Guinea","BO":"Bol\u00edvia","BA":"Bosznia-Hercegovina","BW":"Botswana","BV":"Bouvet-sziget","BR":"Braz\u00edlia","IO":"Brit Indiai-\u00f3ce\u00e1ni Ter\u00fclet","VG":"Brit Virgin-szigetek","BN":"Brunei","BG":"Bulg\u00e1ria","BF":"Burkina Faso","BI":"Burundi","CL":"Chile","CY":"Ciprus","KM":"Comore-szigetek","CK":"Cook-szigetek","CR":"Costa Rica","CW":"Cura\u00e7ao","TD":"Cs\u00e1d","CZ":"Csehorsz\u00e1g","DK":"D\u00e1nia","ZA":"D\u00e9l-afrikai K\u00f6zt\u00e1rsas\u00e1g","KR":"D\u00e9l-Korea","SS":"D\u00e9l-Szud\u00e1n","GS":"D\u00e9li-Georgia \u00e9s D\u00e9li-Sandwich-szigetek","DM":"Dominika","DO":"Dominikai K\u00f6zt\u00e1rsas\u00e1g","DJ":"Dzsibuti","EC":"Ecuador","GQ":"Egyenl\u00edt\u0151i-Guinea","US":"Egyes\u00fclt \u00c1llamok","AE":"Egyes\u00fclt Arab Em\u00edrs\u00e9gek","GB":"Egyes\u00fclt Kir\u00e1lys\u00e1g","EG":"Egyiptom","CI":"Elef\u00e1ntcsontpart","ER":"Eritrea","KP":"\u00c9szak-Korea","MK":"\u00c9szak-Maced\u00f3nia","MP":"\u00c9szaki Mariana-szigetek","EE":"\u00c9sztorsz\u00e1g","ET":"Eti\u00f3pia","FK":"Falkland-szigetek","FO":"Fer\u00f6er szigetek","FJ":"Fidzsi","FI":"Finnorsz\u00e1g","TF":"Francia D\u00e9li Ter\u00fcletek","GF":"Francia Guyana","PF":"Francia Polin\u00e9zia","FR":"Franciaorsz\u00e1g","PH":"F\u00fcl\u00f6p-szigetek","GA":"Gabon","GM":"Gambia","GH":"Gh\u00e1na","GI":"Gibralt\u00e1r","GR":"G\u00f6r\u00f6gorsz\u00e1g","GD":"Grenada","GL":"Gr\u00f6nland","GE":"Gr\u00fazia","GP":"Guadeloupe","GU":"Guam","GT":"Guatemala","GG":"Guernsey","GN":"Guinea","GY":"Guyana","HT":"Haiti","HM":"Heard-sziget \u00e9s McDonald-szigetek","BQ":"Holland Karib-t\u00e9rs\u00e9g","NL":"Hollandia","HN":"Honduras","HK":"Hongkong KKT","HR":"Horv\u00e1torsz\u00e1g","IN":"India","ID":"Indon\u00e9zia","IQ":"Irak","IR":"Ir\u00e1n","IE":"\u00cdrorsz\u00e1g","IS":"Izland","IL":"Izrael","JM":"Jamaica","JP":"Jap\u00e1n","YE":"Jemen","JE":"Jersey","JO":"Jord\u00e1nia","KY":"Kajm\u00e1n-szigetek","KH":"Kambodzsa","CM":"Kamerun","CA":"Kanada","CX":"Kar\u00e1csony-sziget","QA":"Katar","KZ":"Kazahszt\u00e1n","TL":"Kelet-Timor","KE":"Kenya","CN":"K\u00edna","KG":"Kirgiziszt\u00e1n","KI":"Kiribati","CC":"K\u00f3kusz (Keeling)-szigetek","CO":"Kolumbia","CG":"Kong\u00f3 \u2013 Brazzaville","CD":"Kong\u00f3 \u2013 Kinshasa","CF":"K\u00f6z\u00e9p-afrikai K\u00f6zt\u00e1rsas\u00e1g","CU":"Kuba","KW":"Kuvait","LA":"Laosz","PL":"Lengyelorsz\u00e1g","LS":"Lesotho","LV":"Lettorsz\u00e1g","LB":"Libanon","LR":"Lib\u00e9ria","LY":"L\u00edbia","LI":"Liechtenstein","LT":"Litv\u00e1nia","LU":"Luxemburg","MG":"Madagaszk\u00e1r","HU":"Magyarorsz\u00e1g","MO":"Maka\u00f3 KKT","MY":"Malajzia","MW":"Malawi","MV":"Mald\u00edv-szigetek","ML":"Mali","MT":"M\u00e1lta","IM":"Man-sziget","MA":"Marokk\u00f3","MH":"Marshall-szigetek","MQ":"Martinique","MR":"Maurit\u00e1nia","MU":"Mauritius","YT":"Mayotte","MX":"Mexik\u00f3","MM":"Mianmar","FM":"Mikron\u00e9zia","MD":"Moldova","MC":"Monaco","MN":"Mong\u00f3lia","ME":"Montenegr\u00f3","MS":"Montserrat","MZ":"Mozambik","NA":"Nam\u00edbia","NR":"Nauru","DE":"N\u00e9metorsz\u00e1g","NP":"Nep\u00e1l","NI":"Nicaragua","NE":"Niger","NG":"Nig\u00e9ria","NU":"Niue","NF":"Norfolk-sziget","NO":"Norv\u00e9gia","EH":"Nyugat-Szahara","IT":"Olaszorsz\u00e1g","OM":"Om\u00e1n","RU":"Oroszorsz\u00e1g","AM":"\u00d6rm\u00e9nyorsz\u00e1g","PK":"Pakiszt\u00e1n","PW":"Palau","PS":"Palesztin Auton\u00f3mia","PA":"Panama","PG":"P\u00e1pua \u00daj-Guinea","PY":"Paraguay","PE":"Peru","PN":"Pitcairn-szigetek","PT":"Portug\u00e1lia","PR":"Puerto Rico","RE":"R\u00e9union","RO":"Rom\u00e1nia","RW":"Ruanda","KN":"Saint Kitts \u00e9s Nevis","LC":"Saint Lucia","MF":"Saint Martin","VC":"Saint Vincent \u00e9s a Grenadine-szigetek","BL":"Saint-Barth\u00e9lemy","PM":"Saint-Pierre \u00e9s Miquelon","SB":"Salamon-szigetek","SV":"Salvador","SM":"San Marino","ST":"S\u00e3o Tom\u00e9 \u00e9s Pr\u00edncipe","SC":"Seychelle-szigetek","SL":"Sierra Leone","SX":"Sint Maarten","ES":"Spanyolorsz\u00e1g","LK":"Sr\u00ed Lanka","SR":"Suriname","CH":"Sv\u00e1jc","SJ":"Svalbard \u00e9s Jan Mayen","SE":"Sv\u00e9dorsz\u00e1g","WS":"Szamoa","SA":"Sza\u00fad-Ar\u00e1bia","SN":"Szeneg\u00e1l","SH":"Szent Ilona","RS":"Szerbia","SG":"Szingap\u00far","SY":"Sz\u00edria","SK":"Szlov\u00e1kia","SI":"Szlov\u00e9nia","SO":"Szom\u00e1lia","SD":"Szud\u00e1n","SZ":"Szv\u00e1zif\u00f6ld","TJ":"T\u00e1dzsikiszt\u00e1n","TW":"Tajvan","TZ":"Tanz\u00e1nia","TH":"Thaif\u00f6ld","TG":"Togo","TK":"Tokelau","TO":"Tonga","TR":"T\u00f6r\u00f6korsz\u00e1g","TT":"Trinidad \u00e9s Tobago","TN":"Tun\u00e9zia","TC":"Turks- \u00e9s Caicos-szigetek","TV":"Tuvalu","TM":"T\u00fcrkmeniszt\u00e1n","UG":"Uganda","NC":"\u00daj-Kaled\u00f3nia","NZ":"\u00daj-Z\u00e9land","UA":"Ukrajna","UY":"Uruguay","UZ":"\u00dczbegiszt\u00e1n","VU":"Vanuatu","VA":"Vatik\u00e1n","VE":"Venezuela","VN":"Vietn\u00e1m","WF":"Wallis \u00e9s Futuna","ZM":"Zambia","ZW":"Zimbabwe","CV":"Z\u00f6ld-foki K\u00f6zt\u00e1rsas\u00e1g"},"appUrl":{"basePath":""},"unitSystem":{"name":"metric","paceSymbol":"\/km","distanceSymbol":"km","elevationSymbol":"m"}};
+    window.statisticsForStrava.placeholderBrokenImage = "/assets/placeholder-broken.webp";
+</script>
+<script src="/libraries/flowbite.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script src="/libraries/echarts/echarts.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script src="/libraries/echarts/echarts.world.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
+</body>
+</html>

--- a/translations/messages+intl-icu.hu_HU.yaml
+++ b/translations/messages+intl-icu.hu_HU.yaml
@@ -1,0 +1,559 @@
+'42-day fitness trend': '42 napos fitnesz trend'
+'7-day fatigue level': '7 napos fáradtsági szint'
+'< 1.5: Good variety in training': '< 1,5: Jó változatosság az edzésben'
+'> 2.0: High monotony, increased risk': '> 2,0: Magas monotonitás, fokozott kockázat'
+'A 6-hour week scores higher than a 5-hour week.': 'Egy 6 órás hét magasabb pontszámot ér el, mint egy 5 órás.'
+'A high intensity score means a larger share of your training is hard rather than easy.': 'A magas intenzitási pontszám azt jelenti, hogy az edzéseid nagyobb része nehéz, nem könnyű.'
+'A high score means you concentrate more training into fewer, heavier days.': 'A magas pontszám azt jelenti, hogy több edzést koncentrálsz kevesebb, de nehezebb napra.'
+'A:C Ratio': 'A:C arány'
+'A:C optimal in': 'A:C optimális ezután:'
+'ATL (Fatigue)': 'ATL (Fáradtság)'
+'Accumulated fatigue': 'Felhalmozott fáradtság'
+'Active days': 'Aktív napok'
+Activities: Tevékenységek
+Activity: Tevékenység
+'Activity count': 'Tevékenységek száma'
+'Activity heatmap': 'Tevékenységek hőtérképe'
+'Activity locations': 'Tevékenységek helyszínei'
+'Activity start times': 'Tevékenységek kezdési idői'
+'Acute Training Load (Fatigue) - 7-day exponentially weighted average of your daily training load. Represents short-term fatigue.': 'Akut edzésterhelés (Fáradtság) – a napi edzésterhelés 7 napos exponenciálisan súlyozott átlaga. A rövid távú fáradtságot mutatja.'
+'Acute:Chronic Ratio - Ratio of ATL to CTL. Indicates injury risk.': 'Akut:Krónikus arány – az ATL és CTL aránya. Sérülésveszélyt jelöl.'
+'Adaptive & Inclusive Sports': 'Adaptív és inkluzív sportok'
+Afternoon: Délután
+All: Mind
+'All time': 'Összesített'
+'Alpine Ski': 'Alpesi sí'
+Apr: Ápr
+'Ask Mark something...': 'Kérdezz Marktól...'
+'Athlete profile': 'Sportoló profil'
+Aug: Aug
+'Average gradient': 'Átlagos lejtés'
+Avg: Átl
+'Back Country Ski': 'Túrasí'
+Badges: Kitűzők
+Badminton: Tollaslabda
+Basketball: Kosárlabda
+Best: Legjobb
+'Best effort': 'Legjobb teljesítmény'
+'Best efforts': 'Legjobb teljesítmények'
+'Best efforts for {sportType}': 'Legjobb teljesítmények ({sportType})'
+'Build zone (–10)': 'Építési zóna (–10)'
+'CTL (Fitness)': 'CTL (Fitnesz)'
+Cadence: Kadencia
+'Cadence distribution': 'Kadencia eloszlás'
+Calories: Kalória
+'Calories burned': 'Elégetett kalória'
+Canoeing: Kenuzás
+'Carbon saved': 'Megtakarított szén-dioxid'
+'Challenge consistency': 'Kihívás következetesség'
+Challenges: Kihívások
+'Chronic Training Load (Fitness) - 42-day exponentially weighted average of your daily training load. Represents long-term training adaptation.': 'Krónikus edzésterhelés (Fitnesz) – a napi edzésterhelés 42 napos exponenciálisan súlyozott átlaga. A hosszú távú edzésadaptációt mutatja.'
+'Clear chat': 'Chat törlése'
+'Close modal': 'Bezárás'
+'Collapse sidebar': 'Oldalsáv összecsukása'
+Commutes: Ingázások
+'Commutes only': 'Csak ingázások'
+Compare: Összehasonlítás
+'Compare to': 'Összehasonlítás:'
+'Completed {threshold} activities': '{threshold} tevékenység teljesítve'
+'Congrats! You achieved personal bests during this activity.': 'Gratulálok! Személyes rekordot értél el ennél a tevékenységnél.'
+'Consider reducing load': 'Fontold meg a terhelés csökkentését'
+Consistency: Következetesség
+Country: Ország
+Cricket: Krikett
+Crossfit: Crossfit
+'Current Status': 'Jelenlegi állapot'
+'Current streaks': 'Aktuális sorozatok'
+'Custom gear disabled': 'Egyedi felszerelés letiltva'
+Cycling: Kerékpározás
+'Daily TRIMP': 'Napi TRIMP'
+'Daily activities': 'Napi tevékenységek'
+Dance: Tánc
+'Dark mode': 'Sötét mód'
+Dashboard: Irányítópult
+Date: Dátum
+Day: Nap
+'Days needed': 'Szükséges napok'
+'Daytime stats': 'Napszaki statisztikák'
+Dec: Dec
+Density: Sűrűség
+'Detailed instructions are available in the documentation on': 'Részletes utasítások az alábbi dokumentációban találhatók:'
+Details: Részletek
+Device: Eszköz
+Distance: Távolság
+'Distance & Elevation': 'Távolság & szintemelkedés'
+'Distance breakdown': 'Távolság részletezés'
+'Distance in {unit}': 'Távolság ({unit})'
+'Distance over time per gear': 'Távolság időben felszerelésenkén'
+'Distance per month per gear': 'Havi távolság felszerelésenkén'
+Distribution: Eloszlás
+'Doing a mix of cycling, running, swimming, and strength work increases your variety score.': 'A kerékpározás, futás, úszás és erőedzés vegyítése növeli a változatossági pontszámodat.'
+Duration: Időtartam
+'E-Bike Rides': 'E-Bike túrák'
+'E-Mountain Bike Rides': 'E-MTB túrák'
+Eddington: Eddington
+'Effort vs heart rate': 'Erőfeszítés vs pulzus'
+Elev: Szintek
+Elevation: Szintemelkedés
+'Elevation in {unit}': 'Szintemelkedés ({unit})'
+Elliptical: 'Elliptikus gép'
+'Enter fullscreen mode': 'Teljes képernyős mód'
+Evening: Este
+'Excludes commutes': 'Ingázások nélkül'
+'FTP history': 'FTP előzmények'
+'Fastest times': 'Leggyorsabb idők'
+Favourite: Kedvenc
+Feb: Feb
+'Filter on KOM segments': 'Szűrés KOM szegmensekre'
+'Filter on country': 'Szűrés országra'
+'Filter on sport type': 'Szűrés sporttípusra'
+'Filter on starred segments': 'Szűrés csillagozott szegmensekre'
+'First activity in {countryName}': 'Első tevékenység {countryName} országban'
+'First-ever activity recorded': 'Első rögzített tevékenység'
+Firsts: Elsők
+Fitness: Fitnesz
+'Fitness may be declining due to low recent training load': 'A fitnesz csökkenhet az alacsony közelmúltbeli edzésterhelés miatt'
+'Fitness may decline': 'A fitnesz csökkenhet'
+'For example, an Eddington number of 70 would imply that a cyclist has cycled at least 70 km or miles in a day on at least 70 occasions. Achieving a high Eddington number is difficult, since moving from, say, 70 to 75 will (probably) require more than five new long-distance workouts, since any workout shorter than 75 km or miles will no longer be included in the reckoning.': 'Például egy 70-es Eddington-szám azt jelenti, hogy a kerékpáros legalább 70 alkalommal tekert legalább 70 km-t egy nap. Egy magas Eddington-szám elérése nehéz, hiszen pl. a 70-ről 75-re való lépéshez valószínűleg több mint öt új hosszú edzés szükséges, mivel a 75 km-nél rövidebb edzések már nem számítanak bele.'
+'Form (TSB)': 'Forma (TSB)'
+Fri: P
+Friday: Péntek
+GAP: GAP
+Gear: Felszerelés
+'Gear "{gearId}" is referenced in your maintenance config file, but was not imported from Strava. Please check that the gear exists and is correctly synced.': 'A(z) „{gearId}" felszerelés szerepel a karbantartási konfigurációs fájlban, de nem lett importálva a Stravából. Ellenőrizd, hogy a felszerelés létezik és megfelelően szinkronizálva van.'
+'Gear details': 'Felszerelés részletei'
+'Gear maintenance': 'Felszerelés karbantartás'
+'Gear stats': 'Felszerelés statisztikák'
+"Gear that hasn't been used in the last three months, is disabled by default.": 'Az elmúlt három hónapban nem használt felszerelés alapértelmezés szerint le van tiltva.'
+'Gear that is retired is disabled by default.': 'A visszavont felszerelés alapértelmezés szerint le van tiltva.'
+Goal: Cél
+Golf: Golf
+'Good training variety': 'Jó edzésváltozatosság'
+'Google searches': 'Google keresések'
+Gradient: Lejtés
+'Gravel Rides': 'Gravel túrák'
+"Guidelines vary by individual; for more information see Joe Friel's 'The Cyclist's Training Bible' or TrainingPeaks' research documentation.": "Az irányelvek egyénenként változnak; további információkért lásd Joe Friel 'The Cyclist's Training Bible' c. könyvét vagy a TrainingPeaks kutatási dokumentációját."
+HIIT: HIIT
+HR: Pulzus
+'Hand Cycle': 'Kézikerékpár'
+'Heart rate': 'Pulzus'
+'Heart rate distribution': 'Pulzus eloszlás'
+'Heart rate zone distribution over the past month. For effective polarized training, your workouts should primarily fall within the following zones': 'Az elmúlt havi pulzuszóna eloszlás. A hatékony polarizált edzéshez az edzéseidnek elsősorban a következő zónákba kell esniük'
+'Heart rate zones': 'Pulzuszónák'
+Heatmap: Hőtérkép
+High: Magas
+'High fatigue levels may increase injury or burnout risk. Consider reducing load and prioritizing recovery': 'A magas fáradtsági szint növelheti a sérülés vagy kiégés kockázatát. Fontold meg a terhelés csökkentését és a regeneráció előtérbe helyezését'
+'High monotony - increase variety': 'Magas monotonitás – növeld a változatosságot'
+'High risk': 'Magas kockázat'
+'Highly recovered and ready to perform': 'Teljesen regenerálódva, készen a teljesítésre'
+Hikes: Túrák
+History: Előzmények
+'History (6 weeks)': 'Előzmények (6 hét)'
+'How diverse is your training': 'Mennyire változatos az edzésed'
+'How hard is your typical training session': 'Milyen kemény a tipikus edzésed'
+'How long is your typical training session': 'Milyen hosszú a tipikus edzésed'
+'How much do you train on average per week': 'Átlagosan mennyit edzel hetente'
+'How much training you do in total on days you train.': 'Mennyi összes edzést végzel az edzésnapjaidon.'
+'How often do you train': 'Milyen gyakran edzel'
+'Ice Skate': 'Jégkorcsolya'
+Id: Azonosító
+'Image "{imgSrc}" is referenced in your maintenance config file, but was not found in "storage/gear-maintenance"': 'A(z) „{imgSrc}" kép szerepel a karbantartási konfigurációs fájlban, de nem található a „storage/gear-maintenance" mappában'
+Imperial: Angolszász
+"In that time, I've covered {totalDistance}, that's {numberOfTripsAroundTheWorld} trips around the world 🌍 or {numberOfTripsToTheMoonPercent}% of the way to the moon 🌕, and climbed an elevation of {totalElevation} which is {timesMountEverest} times Mount Everest 🏔. All up that's {totalTimeRecorded} of moving time 🎉.": "Ez idő alatt {totalDistance}-t tettem meg, ami {numberOfTripsAroundTheWorld} körülutazás a Föld körül, vagy {numberOfTripsToTheMoonPercent}% az úton a Hold felé, és {totalElevation} szintemelkedést győztem le, ami {timesMountEverest}-szer a Mount Everest magassága. Összesen {totalTimeRecorded} mozgásban töltött idő."
+'Individual thresholds vary based on fitness level.': 'Az egyéni küszöbértékek a fitnesz szinttől függően változnak.'
+'Inline Skate': 'Görkorcsolya'
+Intensity: Intenzitás
+'It looks like no valid gear is attached to any of the components. Please check your config file.': 'Úgy tűnik, hogy egyetlen komponenshez sem tartozik érvényes felszerelés. Kérjük, ellenőrizd a konfigurációs fájlt.'
+Jan: Jan
+Jul: Júl
+Jun: Jún
+KOM: KOM
+Kayaking: Kajak
+'Kite Surf': 'Sárkányos szörfözés'
+Lap: Kör
+Laps: Körök
+'Last 7 days training load': 'Utolsó 7 nap edzésterhelése'
+'Last activity': 'Utolsó tevékenység'
+'Last effort': 'Utolsó teljesítmény'
+'Last effort date': 'Utolsó teljesítmény dátuma'
+'Last maintenance': 'Utolsó karbantartás'
+'Last {numberOfDays} days': 'Utolsó {numberOfDays} nap'
+Lifetime: 'Teljes időszak'
+'Light fatigue with good readiness. A great balance for quality training or longer efforts': 'Enyhe fáradtság jó készenléti állapottal. Kiváló egyensúly a minőségi edzéshez vagy hosszabb erőfeszítésekhez'
+Load: Terhelés
+'Load (CTL/ATL)': 'Terhelés (CTL/ATL)'
+'Loading data...': 'Adatok betöltése...'
+Loading...: 'Betöltés...'
+'Locations over the globe': 'Helyszínek a Földön'
+'Long run': 'Hosszú futás'
+'Longest activity': 'Leghosszabb tevékenység'
+'Longest activity (h)': 'Leghosszabb tevékenység (h)'
+'Longest distance': 'Leghosszabb távolság'
+'Longest streaks': 'Leghosszabb sorozatok'
+Low: Alacsony
+'Low risk': 'Alacsony kockázat'
+'Low training load': 'Alacsony edzésterhelés'
+Maintenance: Karbantartás
+'Maintenance history': 'Karbantartási előzmények'
+Mar: Már
+Max: Max
+'Max gradient': 'Max. lejtés'
+May: Máj
+Medium: Közepes
+Metric: Metrikus
+Metrics: Mutatók
+Milestones: Mérföldkövek
+'Mind & Body Sports': 'Test-lélek sportok'
+'Moderate fatigue with stable fitness. Well suited for consistent day-to-day training': 'Mérsékelt fáradtság stabil fittséggel. Kiváló a következetes napi edzéshez'
+'Moderate monotony': 'Mérsékelt monotonitás'
+Mon: H
+Monday: Hétfő
+Monotony: Monotonitás
+Monthly: Havi
+'Monthly stats': 'Havi statisztikák'
+Morning: Reggel
+'Most elevation': 'Legtöbb szintemelkedés'
+'Most recent activities': 'Legutóbbi tevékenységek'
+'Most recent challenges': 'Legutóbbi kihívások'
+'Most recent milestones': 'Legutóbbi mérföldkövek'
+'Mountain Bike Rides': 'MTB túrák'
+'Moving time': 'Mozgásban töltött idő'
+Name: Név
+Neutral: Semleges
+'New personal best for': 'Új személyes rekord:'
+Night: Éjjel
+'No activities': 'Nincsenek tevékenységek'
+'No data available': 'Nincs elérhető adat'
+'No milestones achieved yet': 'Még nincsenek elért mérföldkövek'
+'No other options to compare with': 'Nincs más összehasonlítási lehetőség'
+None: 'Egyik sem'
+'Nordic Ski': 'Sífutás'
+Normalized: Normalizált
+'Not supported': 'Nem támogatott'
+Nov: Nov
+Now: Most
+'Number of activities per month': 'Havi tevékenységek száma'
+'Number of times completed': 'Teljesítések száma'
+Oct: Okt
+'Older effort': 'Korábbi teljesítmény'
+'On average, that works out to {dailyAverage} per day, a weekly average of {weeklyAverage} and a monthly average of {monthlyAverage} 🐣.': 'Átlagosan ez {dailyAverage} naponta, heti átlag {weeklyAverage} és havi átlag {monthlyAverage}.'
+'One of your gear maintenance tasks is due': 'Az egyik felszerelés karbantartási feladatod esedékes'
+'Optimal training range': 'Optimális edzéstartomány'
+Other: Egyéb
+'Outdoor Sports': 'Szabadtéri sportok'
+Over-fatigued: 'Túlterhelve'
+'Over-fatigued (–30)': 'Túlterhelve (–30)'
+'Overall weekly training stress': 'Heti összes edzésstressz'
+'PB badges': 'Személyes rekord kitűzők'
+'PET bottles produced': 'Előállított PET palackok'
+PRs: 'Személyes rekordok'
+'PRs achieved per month': 'Havi személyes rekordok'
+Pace: Tempó
+'Pace distribution': 'Tempó eloszlás'
+Padel: Padel
+'Peak fresh': 'Csúcsfriss'
+'Peak power outputs': 'Csúcsteljesítmény értékek'
+'Personal Records': 'Személyes rekordok'
+'Personal bests': 'Személyes csúcsok'
+Photo: Fotó
+Photos: Fotók
+'Pickle Ball': 'Pickleball'
+Pilates: Pilates
+'Please address these issues': 'Kérjük, foglalkozz ezekkel a problémákkal'
+'Polarised training (last 30 days)': 'Polarizált edzés (utolsó 30 nap)'
+Power: Teljesítmény
+'Power distribution': 'Teljesítmény eloszlás'
+'Powered by an estimated {caloriesBurned} calories, or roughly {numberOfPizzaSlices} slices of pizza 🍕.': 'Ezt becsült {caloriesBurned} kalória hajtotta, ami nagyjából {numberOfPizzaSlices} szelet pizza.'
+'Prev year': 'Előző év'
+Previous: Előző
+Race: Verseny
+'Racing Score': 'Versenypontszám'
+'Racquet & Paddle Sports': 'Ütős sportok'
+'Racquet Ball': 'Squash labda'
+Ranking: Ranglista
+'Reached {threshold} hours total moving time': '{threshold} óra összes mozgásidő elérve'
+'Reached {threshold} total distance': '{threshold} összes távolság elérve'
+'Reached {threshold} total elevation': '{threshold} összes szintemelkedés elérve'
+'Recent effort': 'Közelmúltbeli teljesítmény'
+'Recording devices': 'Rögzítő eszközök'
+'Recording devices details': 'Rögzítő eszközök részletei'
+'Recovery Timeline': 'Regenerációs idővonal'
+'Recovery forecast': 'Regenerációs előrejelzés'
+'Reduced carbon emission by commuting': 'Csökkentett szén-dioxid kibocsátás ingázással'
+'Relative cost': 'Relatív költség'
+'Rest Days': 'Pihenőnapok'
+'Rest days': 'Pihenőnapok'
+'Rest days in last 7 days': 'Pihenőnapok az utolsó 7 napban'
+'Rest days vs. active days': 'Pihenőnapok vs. aktív napok'
+'Retired gear': 'Visszavont felszerelés'
+Rewind: Visszatekintő
+'Rewind comparisons are only available on larger screens.': 'A visszatekintő összehasonlítások csak nagyobb képernyőkön érhetők el.'
+Rides: 'Kerékpáros túrák'
+'Risk of detraining': 'Edzettség elvesztésének kockázata'
+'Rock Climbing': 'Sziklamászás'
+'Roller Ski': 'Görkorcsolyás sí'
+Rowing: Evezés
+Running: Futás
+Runs: Futások
+Sail: Vitorlázás
+Sat: Szo
+Saturday: Szombat
+Search: Keresés
+'Search activity...': 'Tevékenység keresése...'
+'Search segment...': 'Szegmens keresése...'
+Segments: Szegmensek
+Sep: Szept
+'Show information': 'Információ megjelenítése'
+'Shows how your TSB (Form) and A:C Ratio will recover over time if you take complete rest days.': 'Megmutatja, hogyan fog a TSB (Forma) és az A:C arány idővel helyreállni, ha teljes pihenőnapokat tartasz.'
+"Since I began using Strava {numberOfDaysAgo} ago on {startDate}, I've logged {totalDaysOfWorkingOut} active days of training and adventure.": 'Mióta {numberOfDaysAgo} napja, {startDate}-én elkezdem használni a Stravát, {totalDaysOfWorkingOut} aktív edzés- és kalandnapot rögzítettem.'
+Skateboard: Gördeszkázás
+Skating: Korcsolyázás
+'Slightly fresh': 'Kissé friss'
+Snowboard: Snowboard
+Snowshoe: Hótalp
+Soccer: Labdarúgás
+Socials: Közösségi
+'Someone who regularly trains for 90 minutes will score higher than someone doing mostly short sessions.': 'Aki rendszeresen 90 percet edz, magasabb pontszámot ér el, mint aki főleg rövid edzéseket végez.'
+Speed: Sebesség
+'Speed distribution': 'Sebesség eloszlás'
+Splits: Részidők
+'Sport variety': 'Sporttípus-változatosság'
+Squash: Squash
+'Stair Stepper': 'Lépcső szimulátor'
+'Stand Up Paddling': 'SUP'
+'Start slideshow': 'Diavetítés indítása'
+'Start times': 'Kezdési idők'
+'Statistics for Strava': 'Strava statisztikák'
+'Stats per weekday': 'Statisztikák napokra bontva'
+Status: Állapot
+'Strava profile': 'Strava profil'
+'Streak started on {date}': 'Sorozat kezdete: {date}'
+Streaks: Sorozatok
+Sun: V
+Sunday: Vasárnap
+Surfing: Szörfözés
+Swim: Úszás
+'TSB (Form)': 'TSB (Forma)'
+'TSB positive in': 'TSB pozitív ezután:'
+'Table Tennis': 'Asztalitenisz'
+Tag: Cimke
+'Tag "{maintenanceTaskTag}" was used on "{activityName}", but the gear referenced on that activity is not attached to this component.': 'A(z) „{maintenanceTaskTag}" cimke a(z) „{activityName}" tevékenységben lett használva, de az ahhoz a tevékenységhez kapcsolódó felszerelés nincs csatolva ehhez a komponenshez.'
+'Taper sweet-spot (+15)': 'Taper édes pont (+15)'
+'Team Sports': 'Csapatsportok'
+Tennis: Tenisz
+"That's 1.5 times the distance to the edge of space": 'Ez 1,5-szere az űr határáig terjedő távolságnak'
+"That's 100 days of commitment, triple digits!": 'Ez 100 nap elkötelezettség, háromjegyű!'
+"That's 2 activities per week for nearly 5 years": 'Ez heti 2 tevékenység közel 5 éven át'
+"That's 2 full days of non-stop activity": 'Ez 2 teljes nap folyamatos tevékenység'
+"That's 2 full years of daily activity, incredible!": 'Ez 2 teljes év napi tevékenység, hihetetlen!'
+"That's 2 months without missing a day": 'Ez 2 hónap egyetlen kihagyott nap nélkül'
+"That's 2 months without stopping": 'Ez 2 hónap megállás nélkül'
+"That's 250 days, over two thirds of a year": 'Ez 250 nap, több mint az év kétharmada'
+"That's 3 activities per week for nearly 5 years": 'Ez heti 3 tevékenység közel 5 éven át'
+"That's 3 weeks straight, they say it takes 21 days to build a habit": 'Ez 3 egymást követő hét – azt mondják, 21 napra van szükség egy szokás kialakításához'
+"That's 4 months of unbroken daily activity": 'Ez 4 hónap megszakítatlan napi tevékenység'
+"That's 45 days, halfway to a full quarter": 'Ez 45 nap, félúton egy teljes negyedévhez'
+"That's 5 months, nearly half a year without a rest day": 'Ez 5 hónap, közel fél év pihenőnap nélkül'
+"That's 500 days, well beyond a year of daily activity": 'Ez 500 nap, jócskán túl egy éves napi tevékenységen'
+"That's a full day of non-stop movement": 'Ez egy teljes nap folyamatos mozgás'
+"That's a full fortnight of daily activity": 'Ez egy teljes két hét napi tevékenység'
+"That's a full month of non-stop activity": 'Ez egy teljes hónap folyamatos tevékenység'
+"That's a full month without a rest day": 'Ez egy teljes hónap pihenőnap nélkül'
+"That's a full quarter of daily activity": 'Ez egy teljes negyedév napi tevékenység'
+"That's a full week of daily activity": 'Ez egy teljes hét napi tevékenység'
+"That's a full week of non-stop movement": 'Ez egy teljes hét folyamatos mozgás'
+"That's a full year of daily activity": 'Ez egy teljes év napi tevékenység'
+"That's about 3.5 months of continuous movement": 'Ez körülbelül 3,5 hónap folyamatos mozgás'
+"That's about one activity per week for a year": 'Ez körülbelül heti egy tevékenység egy éven át'
+"That's about one activity per week for half a year": 'Ez körülbelül heti egy tevékenység fél éven át'
+"That's about one activity per week for two months": 'Ez körülbelül heti egy tevékenység két hónapon át'
+"That's almost 2 activities per week for a year": 'Ez majdnem heti 2 tevékenység egy éven át'
+"That's almost 21 days of continuous movement": 'Ez majdnem 21 nap folyamatos mozgás'
+"That's almost 3 activities per week for 7 years": 'Ez majdnem heti 3 tevékenység 7 éven át'
+"That's an activity almost every day for 27 years": 'Ez majdnem minden nap tevékenység 27 éven át'
+"That's an activity every day for almost 7 years": 'Ez minden nap tevékenység majdnem 7 éven át'
+"That's an activity every day for nearly 11 years": 'Ez minden nap tevékenység közel 11 éven át'
+"That's an activity every day for nearly 14 years": 'Ez minden nap tevékenység közel 14 éven át'
+"That's an activity every day for over 20 years": 'Ez minden nap tevékenység több mint 20 éven át'
+"That's an activity every day for over 8 years": 'Ez minden nap tevékenység több mint 8 éven át'
+"That's climbing Mount Everest twice": 'Ez kétszer a Mount Everest megmászása'
+"That's climbing to the edge of space and back 5 times": 'Ez ötszörös oda-vissza utazás az űr határáig'
+"That's cruising altitude of a commercial airplane": 'Ez egy kereskedelmi repülőgép utazómagassága'
+"That's deeper than the deepest known cave on Earth": 'Ez mélyebb a Föld legmélyebb ismert barlangjánál'
+"That's five times around the Earth": 'Ez ötszörös körülutazás a Föld körül'
+"That's half a year without skipping a single day": 'Ez fél év egyetlen kihagyott nap nélkül'
+"That's higher than Felix Baumgartner's space jump": 'Ez magasabb Felix Baumgartner űrugrásánál'
+"That's higher than the International Space Station's orbit": 'Ez magasabb a Nemzetközi Űrállomás pályájánál'
+"That's higher than the summit of Mont Blanc": 'Ez magasabb a Mont Blanc csúcsánál'
+"That's more than 10 days of non-stop movement": 'Ez több mint 10 nap folyamatos mozgás'
+"That's more than 10 months of continuous movement": 'Ez több mint 10 hónap folyamatos mozgás'
+"That's more than 2 Eiffel Towers stacked up": 'Ez több mint 2 egymásra rakott Eiffel-torony'
+"That's more than 2.5 times around the Earth": 'Ez több mint 2,5-szeres körülutazás a Föld körül'
+"That's more than 4 days of continuous activity": 'Ez több mint 4 nap folyamatos tevékenység'
+"That's more than 4 months of non-stop activity": 'Ez több mint 4 hónap folyamatos tevékenység'
+"That's more than 41 days of non-stop movement": 'Ez több mint 41 nap folyamatos mozgás'
+"That's more than 5 activities per week for 7 years": 'Ez több mint heti 5 tevékenység 7 éven át'
+"That's more than 8 times the height of Mount Everest": 'Ez több mint 8-szorosa a Mount Everest magasságának'
+"That's more than a full year of non-stop movement": 'Ez több mint egy teljes év folyamatos mozgás'
+"That's more than halfway around the Earth": 'Ez több mint a Föld félkerülete'
+"That's more than halfway to the ISS": 'Ez több mint félúton a Nemzetközi Űrállomásig'
+"That's more than the circumference of Mars": 'Ez több mint a Mars kerülete'
+"That's more than the distance from Earth to the Moon": 'Ez több mint a Föld-Hold távolság'
+"That's nearly 3 months of non-stop activity": 'Ez közel 3 hónap folyamatos tevékenység'
+"That's nearly 4 activities per week for 7 years": 'Ez közel heti 4 tevékenység 7 éven át'
+"That's nearly 5 activities per week for a year": 'Ez közel heti 5 tevékenység egy éven át'
+"That's nearly 7 months of non-stop activity": 'Ez közel 7 hónap folyamatos tevékenység'
+"That's nearly climbing Mount Everest 3 times": 'Ez közel a Mount Everest háromszori megmászása'
+"That's nearly the altitude of the International Space Station": 'Ez közel a Nemzetközi Űrállomás magassága'
+"That's nearly twice around the Earth": 'Ez közel kétszeres körülutazás a Föld körül'
+"That's nearly twice the altitude of the International Space Station": 'Ez közel kétszerese a Nemzetközi Űrállomás magasságának'
+"That's over 5.5 months of continuous movement": 'Ez több mint 5,5 hónap folyamatos mozgás'
+"That's roughly a quarter of the way around the Earth": 'Ez körülbelül a Föld kerületének negyede'
+"That's roughly the diameter of Jupiter": 'Ez körülbelül a Jupiter átmérője'
+"That's roughly the diameter of Neptune": 'Ez körülbelül a Neptunusz átmérője'
+"That's roughly the distance from London to Perth": 'Ez körülbelül a Londontól Perthi távolság'
+"That's roughly the distance from Madrid to Barcelona": 'Ez körülbelül a Madridtól Barcelonáig terjedő távolság'
+"That's roughly the distance light travels in one second": 'Ez körülbelül a fény által egy másodperc alatt megtett távolság'
+"That's roughly the length of France": 'Ez körülbelül Franciaország hossza'
+"That's roughly the length of the Danube river": 'Ez körülbelül a Duna hossza'
+"That's roughly the length of the island of Jamaica": 'Ez körülbelül Jamaika szigetének hossza'
+"That's taller than the Empire State Building": 'Ez magasabb az Empire State Buildingnél'
+"That's the altitude of a satellite in low Earth orbit": 'Ez egy alacsony Föld körüli pályán keringő műhold magassága'
+"That's the circumference of the Earth": 'Ez a Föld kerülete'
+"That's the distance from Earth to the Moon": 'Ez a Föld-Hold távolság'
+"That's the distance to the edge of space, straight up": 'Ez az egyenes felfelé mért távolság az űr határáig'
+"That's the edge of space, the Kármán line": 'Ez az űr határa, a Kármán-vonal'
+"That's the height of Mount Everest": 'Ez a Mount Everest magassága'
+"That's the height of the Eiffel Tower": 'Ez az Eiffel-torony magassága'
+"That's the length of the Great Wall of China": 'Ez a Kínai Nagy Fal hossza'
+"That's three quarters of the way around the Earth": 'Ez a Föld kerületének háromnegyede'
+"That's {number} days of at least {distance}": 'Ez {number} nap legalább {distance}-vel'
+'The Eddington number in the context of cycling or running is defined as the maximum number E such that the athlete has covered at least E km on at least E days.': 'Az Eddington-szám kerékpározás vagy futás kontextusában a maximális E szám, amelyre az atléta legalább E napot teljesített legalább E km-rel.'
+'These badges are dynamically created. You can use them in any &lt;img&gt; tag': 'Ezek a kitűzők dinamikusan jönnek létre. Bármely &lt;img&gt; tagben használhatod őket'
+Thinking...: 'Gondolkodás...'
+'This chart summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.': 'Ez a diagram összefoglalja, hogyan edzel. Minden tengely különböző normalizált edzési szokást tükröz, így a magasabb értékek erősebb hangsúlyt jelentenek.'
+'This feature is currently disabled': 'Ez a funkció jelenleg le van tiltva'
+Thu: Cs
+Thursday: Csütörtök
+Time: Idő
+'Times completed': 'Teljesítések száma'
+'To enable it, configure {configFile} and rebuild the files for the changes to take effect': 'Az engedélyezéséhez konfiguráld a(z) {configFile} fájlt, és építsd újra a fájlokat a változtatások életbe lépéséhez'
+'Toggle sidebar': 'Oldalsáv ki/be'
+'Top 10': 'Top 10'
+'Total distance per month': 'Havi össztávolság'
+'Total elevation per month': 'Havi össz szintemelkedés'
+'Total hours': 'Összes óra'
+'Total hours spent per gear': 'Összes óra felszerelésenkén'
+'Total hours spent per sport type': 'Összes óra sporttípusonként'
+'Total kudos and comments received': 'Összes kapott kudos és hozzászólás'
+'Trail Runs': 'Terepfutások'
+'Training 4–5 days every week scores higher than doing everything in one or two days.': 'A heti 4–5 napos edzés magasabb pontszámot ér el, mint ha mindent egy-két napra zsúfolnak.'
+'Training Impulse - Training load metric that accounts for intensity and duration.': 'Edzési impulzus – az intenzitást és az időtartamot figyelembe vevő edzésterhelési mutató.'
+'Training Load Analysis': 'Edzésterhelés elemzés'
+'Training Monotony - Ratio of average daily load to standard deviation. Indicates training variety.': 'Edzési monotonitás – a napi átlagterhelés és a szórás aránya. Az edzés változatosságát mutatja.'
+'Training Stress Balance (Form) – The difference between fitness (CTL) and fatigue (ATL). Reflects how ready you are to perform.': 'Edzési stressz egyensúly (Forma) – a fitnesz (CTL) és a fáradtság (ATL) különbsége. Megmutatja, mennyire vagy felkészülve a teljesítésre.'
+'Training goals': 'Edzési célok'
+'Training load is accumulating, recovery days are important': 'Az edzésterhelés halmozódik, a regenerációs napok fontosak'
+Tue: K
+Tuesday: Kedd
+Unspecified: Meghatározatlan
+'Updated on': 'Frissítve:'
+'User badge': 'Felhasználói kitűző'
+'Velo Mobiles': 'Velomobil'
+'Very high': 'Nagyon magas'
+'View all': 'Összes megtekintése'
+'View details': 'Részletek megtekintése'
+'Virtual Rides': 'Virtuális kerékpározás'
+'Virtual Row': 'Virtuális evezés'
+'Virtual Runs': 'Virtuális futások'
+'Virtual workout assistant': 'Virtuális edzési asszisztens'
+Volleyball: Röplabda
+Volume: Mennyiség
+Walking: Gyaloglás
+Walks: Séták
+'Water Sports': 'Vízi sportok'
+'We detected following issues': 'A következő problémákat észleltük'
+Wed: Sze
+Wednesday: Szerda
+Weekly: Heti
+'Weekly Strain': 'Heti terhelés'
+'Weekly Strain - Product of weekly training load and monotony. Overall training stress.': 'Heti terhelés – a heti edzésterhelés és a monotonitás szorzata. Összesített edzési stressz.'
+'Weekly TRIMP': 'Heti TRIMP'
+'Weekly stats': 'Heti statisztikák'
+Weight: Súly
+'Weight Training': 'Súlyzós edzés'
+'Weight history': 'Súly előzmények'
+Wheelchair: Kerekesszék
+'Wind Surf': 'Windsurfing'
+'Winter Sports': 'Téli sportok'
+Workout: Edzés
+'Workout assistant': 'Edzési asszisztens'
+'Workout type': 'Edzés típusa'
+YTD: ÉTD
+Year: Év
+Yearly: Éves
+'Yearly stats': 'Éves statisztikák'
+Yoga: Jóga
+"You recorded workouts in {numberOfCountriesWithWorkouts} different countries, that's {percentage} of all countries 🌍": "{numberOfCountriesWithWorkouts} különböző országban rögzítettél edzéseket, ez az összes ország {percentage}-a 🌍"
+'Your PB badge': 'Személyes rekord kitűződ'
+'Your Strava badge': 'Strava kitűződ'
+'Your Strava {year} rewind will be available on the 24th of December.': 'A(z) {year}-es Strava visszatekintőd december 24-én lesz elérhető.'
+'Your Zwift badge': 'Zwift kitűződ'
+'Your badge(s)': 'Kitűződ(ök)'
+'Z1-2 (Low)': 'Z1-2 (Alacsony)'
+'Z3 (Mod)': 'Z3 (Közepes)'
+'Z4-5 (High)': 'Z4-5 (Magas)'
+'Zone 1 (recovery)': '1. zóna (regeneráció)'
+'Zone 2 (aerobic)': '2. zóna (aerob)'
+'Zone 3 (aerobic/anaerobic)': '3. zóna (aerob/anaerob)'
+'Zone 4 (anaerobic)': '4. zóna (anaerob)'
+'Zone 5 (maximal)': '5. zóna (maximális)'
+'Zwift Statistics': 'Zwift statisztikák'
+'Zwift badge': 'Zwift kitűző'
+'Zwift stats': 'Zwift statisztikák'
+activities: tevékenységek
+and: és
+'average gradient': 'átlagos lejtés'
+avg: átl
+bpm: bpm
+clear: törlés
+comments: hozzászólások
+compare: összehasonlítás
+'day(s)': 'nap(ok)'
+days: napok
+'days needed for next Eddington': 'napok a következő Eddington-számhoz'
+history: előzmények
+hours: órák
+hrs: h
+kudos: kudos
+'last {numberOfDays} days': 'utolsó {numberOfDays} nap'
+max: max
+'max gradient': 'max. lejtés'
+min: min
+months: hónapok
+more: több
+n/a: n/a
+never: soha
+'on': 'ekkor:'
+per: '/'
+'per activity': 'tevékenységenkén'
+'per hour': 'óránként'
+'reached Eddington number {number}': '{number}-es Eddington-szám elérve'
+to: '-ig'
+total: összesen
+weeks: hetek
+workouts: edzések
+'{daysSinceLastTagged} days': '{daysSinceLastTagged} nap'
+'{days} consecutive days of activity': '{days} egymást követő aktív nap'
+'{hoursSinceLastTagged} hours': '{hoursSinceLastTagged} óra'
+'{maintenanceTaskLabel} every {interval}': '{maintenanceTaskLabel} minden {interval}'
+'{numberOfActivities} activities': '{numberOfActivities} tevékenység'
+'{numberOfActivities} activities in {year}': '{numberOfActivities} tevékenység {year}-ben'
+'{numberOfMonths} months': '{numberOfMonths} hónap'
+'{numberOfResults} photos based on your active filters': '{numberOfResults} fotó az aktív szűrők alapján'
+'{numberOfResults} results based on your active filters': '{numberOfResults} eredmény az aktív szűrők alapján'
+'{numberOfResults} routes based on your active filters': '{numberOfResults} útvonal az aktív szűrők alapján'
+'{numberOfWeeks} weeks': '{numberOfWeeks} hét'
+'{threshold} hours using {gearName}': '{threshold} óra {gearName} felhasználásával'
+'{threshold} total distance using {gearName}': '{threshold} össztávolság {gearName} felhasználásával'
+'{threshold} total elevation using {gearName}': '{threshold} össz szintemelkedés {gearName} felhasználásával'

--- a/translations/messages+intl-icu.hu_HU.yaml
+++ b/translations/messages+intl-icu.hu_HU.yaml
@@ -327,9 +327,6 @@ Squash: Squash
 'Stats per weekday': 'Statisztikák napokra bontva'
 Status: Állapot
 'Strava profile': 'Strava profil'
-'Sync Strava': 'Strava szinkronizálás'
-'Syncing...': 'Szinkronizálás...'
-'Import started!': 'Import elindítva!'
 'Streak started on {date}': 'Sorozat kezdete: {date}'
 Streaks: Sorozatok
 Sun: V

--- a/translations/messages+intl-icu.hu_HU.yaml
+++ b/translations/messages+intl-icu.hu_HU.yaml
@@ -159,7 +159,7 @@ History: Előzmények
 Id: Azonosító
 'Image "{imgSrc}" is referenced in your maintenance config file, but was not found in "storage/gear-maintenance"': 'A(z) „{imgSrc}" kép szerepel a karbantartási konfigurációs fájlban, de nem található a „storage/gear-maintenance" mappában'
 Imperial: Angolszász
-"In that time, I've covered {totalDistance}, that's {numberOfTripsAroundTheWorld} trips around the world 🌍 or {numberOfTripsToTheMoonPercent}% of the way to the moon 🌕, and climbed an elevation of {totalElevation} which is {timesMountEverest} times Mount Everest 🏔. All up that's {totalTimeRecorded} of moving time 🎉.": "Ez idő alatt {totalDistance}-t tettem meg, ami {numberOfTripsAroundTheWorld} körülutazás a Föld körül, vagy {numberOfTripsToTheMoonPercent}% az úton a Hold felé, és {totalElevation} szintemelkedést győztem le, ami {timesMountEverest}-szer a Mount Everest magassága. Összesen {totalTimeRecorded} mozgásban töltött idő."
+"In that time, I’ve covered {totalDistance}, that's {numberOfTripsAroundTheWorld} trips around the world 🌍 or {numberOfTripsToTheMoonPercent}% of the way to the moon 🌕, and climbed an elevation of {totalElevation} which is {timesMountEverest} times Mount Everest 🏔. All up that's {totalTimeRecorded} of moving time 🎉.": "Ez idő alatt {totalDistance}-t tettem meg, ami {numberOfTripsAroundTheWorld} körülutazás a Föld körül, vagy {numberOfTripsToTheMoonPercent}% az úton a Hold felé, és {totalElevation} szintemelkedést győztem le, ami {timesMountEverest}-szer a Mount Everest magassága. Összesen {totalTimeRecorded} mozgásban töltött idő."
 'Individual thresholds vary based on fitness level.': 'Az egyéni küszöbértékek a fitnesz szinttől függően változnak.'
 'Inline Skate': 'Görkorcsolya'
 Intensity: Intenzitás
@@ -327,6 +327,9 @@ Squash: Squash
 'Stats per weekday': 'Statisztikák napokra bontva'
 Status: Állapot
 'Strava profile': 'Strava profil'
+'Sync Strava': 'Strava szinkronizálás'
+'Syncing...': 'Szinkronizálás...'
+'Import started!': 'Import elindítva!'
 'Streak started on {date}': 'Sorozat kezdete: {date}'
 Streaks: Sorozatok
 Sun: V


### PR DESCRIPTION
## Summary

This PR adds full Hungarian (`hu_HU`) locale support:

- **`translations/messages+intl-icu.hu_HU.yaml`** — complete Hungarian translation of all UI strings (~560 lines, matching the `en_US` reference file structure)
- **`src/Infrastructure/Localisation/Locale.php`** — adds `hu_HU` to the `Locale` enum so the locale is accepted as a valid configuration value

## How to enable

In `config/app/config.yaml`:
```yaml
appearance:
  locale: 'hu_HU'
```

And in the Docker environment:
```yaml
environment:
  LOCALE: "hu_HU"
```

## Notes

- Translation follows ICU message format used by the existing locale files
- All pluralization rules use the `{count, plural, one{...} other{...}}` pattern
- Tested on a self-hosted instance with real Strava data