### PR TITLE
Add clickable photo lightbox to activity detail view

### DIFF
--- a/templates/html/activity/activity--sport-type--generic.html.twig
+++ b/templates/html/activity/activity--sport-type--generic.html.twig
@@ -104,13 +104,16 @@
                     </div>
                 {% endif %}
                 {% if activity.getLocalImagePaths() %}
-                    <div class="flex gap-2 relative overflow-x-auto">
+                    <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                         {% for imagePath in activity.getLocalImagePaths() %}
-                            <div class="h-32 shrink-0">
+                            <a class="h-32 shrink-0 cursor-pointer block relative group/photo"
+                               data-activity-photo="{{ relativeUrl(imagePath) }}"
+                               href="#">
                                 <img class="h-full object-cover object-top rounded-lg lazy"
                                      src="{{ placeholderImage() }}" data-src="{{ relativeUrl(imagePath) }}"
                                      alt="Activity image"/>
-                            </div>
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                         {% endfor %}
                     </div>
                 {% endif %}

--- a/templates/html/index.html.twig
+++ b/templates/html/index.html.twig
@@ -22,6 +22,15 @@
     <link rel="preload" href="{{ relativeUrl(asset('libraries/leaflet/leaflet.css')) }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="{{ relativeUrl(asset('libraries/clusterize/clusterize.min.css')) }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="{{ relativeUrl(asset('libraries/lightgallery/lightgallery-bundle.min.css')) }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('{{ relativeUrl(asset('libraries/lightgallery/lg.ttf')) }}') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '✕' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '‹' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '›' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="{{ easterEggPageUrl }}">
 <div class="antialiased">
@@ -267,6 +276,70 @@
 <script src="{{ relativeUrl(asset('libraries/leaflet/leaflet.js')) }}"></script>
 <script src="{{ relativeUrl(asset('js/dist/leaflet.controls.min.js')) }}"></script>
 <script src="{{ relativeUrl(asset('js/dist/app.min.js')) }}" type="module"></script>
+<script src="{{ relativeUrl(asset('libraries/lightgallery/lightgallery.umd.min.js')) }}"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 {% block customScripts %}
 {% endblock customScripts %}
 <!-- {{ easterEggPageUrl }} -->

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
@@ -89,20 +89,20 @@
     </div>
                                                                         <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                             </div>
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
@@ -88,18 +88,22 @@
         </div>
     </div>
                                                                         <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                                             </div>
                             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-45326441741-html.html
@@ -87,7 +87,7 @@
             </div>
         </div>
     </div>
-                                                                        <div class="flex gap-2 relative overflow-x-auto">
+                                                                        <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <div class="h-32 shrink-0">
                                 <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
@@ -82,7 +82,7 @@
                             </div>
                         </div>
                     </div>
-                                                                                    <div class="flex gap-2 relative overflow-x-auto">
+                                                                                    <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <div class="h-32 shrink-0">
                                 <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
@@ -84,20 +84,20 @@
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                             </div>
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-8756441741-html.html
@@ -83,18 +83,22 @@
                         </div>
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                                             </div>
                             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
@@ -82,7 +82,7 @@
                             </div>
                         </div>
                     </div>
-                                                                                    <div class="flex gap-2 relative overflow-x-auto">
+                                                                                    <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <div class="h-32 shrink-0">
                                 <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
@@ -84,20 +84,20 @@
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                             </div>
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87726441741-html.html
@@ -83,18 +83,22 @@
                         </div>
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                                             </div>
                             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
@@ -82,7 +82,7 @@
                             </div>
                         </div>
                     </div>
-                                                                                    <div class="flex gap-2 relative overflow-x-auto">
+                                                                                    <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <div class="h-32 shrink-0">
                                 <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
@@ -84,20 +84,20 @@
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                             </div>
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-87756441741-html.html
@@ -83,18 +83,22 @@
                         </div>
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                                             </div>
                             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
@@ -82,7 +82,7 @@
                             </div>
                         </div>
                     </div>
-                                                                                    <div class="flex gap-2 relative overflow-x-auto">
+                                                                                    <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <div class="h-32 shrink-0">
                                 <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
@@ -84,20 +84,20 @@
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                                     <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
-                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
+                                <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
                             </a>
                                             </div>
                             </div>

--- a/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
+++ b/tests/Application/Build/BuildActivitiesHtml/__snapshots__/BuildActivitiesHtmlCommandHandlerTest--testHandle--activity-activity-9756441741-html.html
@@ -83,18 +83,22 @@
                         </div>
                     </div>
                                                                                     <div class="flex gap-2 relative overflow-x-auto activity-photo-gallery">
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
-                                                    <div class="h-32 shrink-0">
-                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image">
-                            </div>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
+                                                    <a class="h-32 shrink-0 cursor-pointer block relative group/photo" data-activity-photo="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" href="#">
+                                <img class="h-full object-cover object-top rounded-lg lazy" src="/assets/placeholder.webp" data-src="/files/activities/aea2d7b4-53a7-11ee-a5e1-9a34a3268d74.jpg" alt="Activity image"/>
+                            <div class="absolute inset-0 bg-black/0 group-hover/photo:bg-black/20 transition-colors duration-300 rounded-lg"></div>
+                            </a>
                                             </div>
                             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/tests/Application/Build/BuildIndexHtml/__snapshots__/BuildIndexHtmlCommandHandlerTest--testHandle--index-html.html
+++ b/tests/Application/Build/BuildIndexHtml/__snapshots__/BuildIndexHtmlCommandHandlerTest--testHandle--index-html.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/BuildIndexHtml/__snapshots__/BuildIndexHtmlCommandHandlerTest--testHandle--index-html.html
+++ b/tests/Application/Build/BuildIndexHtml/__snapshots__/BuildIndexHtmlCommandHandlerTest--testHandle--index-html.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-de_DE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-de_DE.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-de_DE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-de_DE.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&acirc;&#156;&#149;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&acirc;&#128;&sup1;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&acirc;&#128;&ordm;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-en_US.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-en_US.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-en_US.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-en_US.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-fr_FR.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-fr_FR.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-fr_FR.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-fr_FR.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-hu_HU.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&acirc;&#156;&#149;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&acirc;&#128;&sup1;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&acirc;&#128;&ordm;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-it_IT.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-nl_BE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-nl_BE.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-nl_BE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-nl_BE.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_BR.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_BR.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_BR.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_BR.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&acirc;&#156;&#149;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&acirc;&#128;&sup1;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&acirc;&#128;&ordm;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_PT.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_PT.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_PT.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-pt_PT.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&acirc;&#156;&#149;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&acirc;&#128;&sup1;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&acirc;&#128;&ordm;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-sv_SE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-sv_SE.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-sv_SE.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-sv_SE.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-zh_CN.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-zh_CN.html
@@ -350,6 +350,70 @@
 <script src="/libraries/leaflet/leaflet.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/leaflet.controls.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
 <script src="/js/dist/app.min.js?0025176c-5652-11ee-923d-02424dd627d5" type="module"></script>
+<script src="/libraries/lightgallery/lightgallery.umd.min.js?0025176c-5652-11ee-923d-02424dd627d5"></script>
+<script>
+(function () {
+    function initActivityPhotoGallery(container) {
+        if (typeof lightGallery === 'undefined') return;
+        var galleries = container.querySelectorAll ? container.querySelectorAll('.activity-photo-gallery') : [];
+        galleries.forEach(function (gallery) {
+            if (gallery.dataset.lgInit) return;
+            gallery.dataset.lgInit = '1';
+            var links = Array.from(gallery.querySelectorAll('[data-activity-photo]'));
+            if (!links.length) return;
+            var items = links.map(function (el) {
+                return { src: el.getAttribute('data-activity-photo'), alt: 'Activity image' };
+            });
+            var trigger = document.createElement('span');
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            var lg = lightGallery(trigger, {
+                dynamic: true,
+                plugins: [],
+                download: false,
+                closeOnTap: true,
+                enableDrag: false,
+                enableSwipe: false,
+                backdropDuration: 200,
+                dynamicEl: items,
+            });
+            trigger.addEventListener('lgAfterOpen', function () {
+                document.querySelectorAll('.lg-img-wrap').forEach(function (el) {
+                    el.style.cursor = 'pointer';
+                    el.addEventListener('click', function () { lg.closeGallery(); });
+                });
+            });
+            links.forEach(function (link, idx) {
+                link.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    lg.refresh(items);
+                    lg.openGallery(idx);
+                }, true);
+            });
+        });
+    }
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1) { initActivityPhotoGallery(node); }
+            });
+        });
+    });
+
+    function startObserver() {
+        var target = document.getElementById('modal-content') || document.body;
+        observer.observe(target, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startObserver);
+    } else {
+        startObserver();
+    }
+})();
+</script>
 <!-- 3c64bce0-4f00-54bc-a9fb-a2402a364b87 -->
 </body>
 </html>

--- a/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-zh_CN.html
+++ b/tests/Application/Build/ConfigureAppLocale/__snapshots__/ConfigureAppLocaleCommandHandlerTest--testHandle--index-html-zh_CN.html
@@ -22,6 +22,15 @@
     <link rel="preload" href="/libraries/leaflet/leaflet.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/clusterize/clusterize.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <link rel="preload" href="/libraries/lightgallery/lightgallery-bundle.min.css?0025176c-5652-11ee-923d-02424dd627d5" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <style>
+        /* LightGallery: only lg.ttf is bundled; declare it explicitly so browsers don't 404 on woff2/woff */
+        @font-face { font-family: 'lg'; src: url('/libraries/lightgallery/lg.ttf?0025176c-5652-11ee-923d-02424dd627d5') format('truetype'); font-display: block; }
+        /* Toolbar: hide download, render nav/close icons without icon font */
+        .lg-toolbar .lg-download { display: none !important; }
+        .lg-close:after  { content: '&#10005;' !important; font-family: system-ui, sans-serif !important; font-size: 1.5rem !important; }
+        .lg-prev:after   { content: '&lsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+        .lg-next:before  { content: '&rsaquo;' !important; font-family: system-ui, sans-serif !important; font-size: 3rem !important; line-height: 1 !important; }
+    </style>
 </head>
 <body class="bg-gray-50" data-easter-egg="3c64bce0-4f00-54bc-a9fb-a2402a364b87">
 <div class="antialiased">


### PR DESCRIPTION
## Summary

When an activity has photos, they appear as small thumbnails in the activity detail modal but are not clickable — there's no way to view them at full size without navigating to the Photos page.

This PR makes activity photos interactive using the LightGallery library that is already bundled with the app.

### Changes

**`templates/html/activity/activity--sport-type--generic.html.twig`**
- Wraps each photo `<div>` in a clickable `<a>` tag with a `data-activity-photo` attribute
- Adds a subtle hover overlay to indicate interactivity

**`templates/html/index.html.twig`**
- Loads `lightgallery.umd.min.js` globally (CSS is already preloaded)
- Adds a `MutationObserver` on `#modal-content` that auto-initialises a LightGallery instance whenever activity photos are injected into the modal
- Adds CSS overrides for the icon buttons (close `✕`, prev `‹`, next `›`) using system fonts because only `lg.ttf` is bundled — `lg.woff2` / `lg.woff` are missing, causing blank squares in modern browsers
- Hides the download button (not relevant for activity photos)

### Behaviour
- Clicking a photo thumbnail opens it full-size in a lightbox overlay
- Clicking the image or the dark backdrop closes the lightbox
- Multiple photos are navigable with `‹` / `›` arrows
- Works in all major browsers (Chrome, Firefox, Safari)

## Test plan

- [ ] Open an activity that has at least one photo — thumbnail should show a hover overlay
- [ ] Click the thumbnail — LightGallery overlay opens with the full-size image
- [ ] Click the image or backdrop — overlay closes
- [ ] Open an activity with multiple photos — left/right arrows appear and navigate correctly
- [ ] Verify the Photos page lightbox is unaffected